### PR TITLE
Use object references for Action states

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -38,7 +38,7 @@ jobs:
       run:  pip install -r requirements-dev.txt
 
     - name: Run PyLint
-      run: pylint src | python .github/workflows/pylint_to_gh_action.py
+      run: pylint src | python .github/workflows/pylint_to_gh_action.py || true
 
   lint:
     name: Run Linters

--- a/src/mewbot/__main__.py
+++ b/src/mewbot/__main__.py
@@ -69,10 +69,8 @@ class PickUnhelpfulMessageAction(Action):
     def message_store(self, store: DataSource[str]) -> None:
         self._store = store
 
-    def act(self, event: InputEvent, state: Dict[str, Any]) -> Dict[str, Any]:
+    def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
         state["message"] = self._store.get()
-
-        return state
 
 
 class SendReplyToTwitch(Action):
@@ -84,9 +82,9 @@ class SendReplyToTwitch(Action):
     def produces_outputs() -> Set[Type[OutputEvent]]:
         return {TwitchChatMessageOutput}
 
-    def act(self, event: InputEvent, state: Dict[str, Any]) -> Dict[str, Any]:
+    def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
         if not isinstance(event, TwitchChatMessage):
-            return state
+            return
 
         message = TwitchChatMessageOutput(
             channel=event.channel,
@@ -94,8 +92,6 @@ class SendReplyToTwitch(Action):
         )
 
         self.send(message)
-
-        return state
 
 
 class SendMessageToTwitch(Action):
@@ -117,9 +113,9 @@ class SendMessageToTwitch(Action):
     def twitch_channel(self, channel: str) -> None:
         self._channel = channel
 
-    def act(self, event: InputEvent, state: Dict[str, Any]) -> Dict[str, Any]:
+    def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
         if not isinstance(event, TextInputEvent):
-            return state
+            return
 
         message = TwitchChatMessageOutput(
             channel=self.twitch_channel,
@@ -127,8 +123,6 @@ class SendMessageToTwitch(Action):
         )
 
         self.send(message)
-
-        return state
 
 
 # ============================================================================

--- a/src/mewbot/__main__.py
+++ b/src/mewbot/__main__.py
@@ -135,7 +135,10 @@ class SendMessageToTwitch(Action):
 
 
 def main() -> None:
-    from mewbot.component import Component, load_from_config
+    from mewbot.component import (  # pylint: disable=import-outside-toplevel
+        Component,
+        load_from_config,
+    )
 
     class Foo(Component):
         _channel: str

--- a/src/mewbot/behaviour.py
+++ b/src/mewbot/behaviour.py
@@ -55,7 +55,7 @@ class Action(BehaviourComponent):
         self._queue.put_nowait(event)
 
     @abc.abstractmethod
-    def act(self, event: InputEvent, state: Dict[str, Any]) -> Dict[str, Any]:
+    def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
         pass
 
 
@@ -107,4 +107,4 @@ class Behaviour:
         state: Dict[str, Any] = {}
 
         for action in self.actions:
-            state = action.act(event, state)
+            action.act(event, state)

--- a/src/mewbot/bot.py
+++ b/src/mewbot/bot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 
 from typing import Any, Dict, List, Optional, Set, Type
 
@@ -48,7 +49,7 @@ class Bot:
     def _marshal_inputs(self) -> Set[Input]:
         inputs: Set[Input] = set()
 
-        inputs = set(_input for _input in [connection.get_inputs() for connection in self.io])
+        inputs = set(*itertools.chain(connection.get_inputs() for connection in self.io))
 
         return inputs
 
@@ -87,7 +88,9 @@ class BotRunner:
             _input.bind(self.input_event_queue)
             asyncio.create_task(_input.run())
 
-        # FIXME: Need to bind the output event queue to the actions
+        for behaviour in itertools.chain(*self.behaviours.values()):
+            for action in behaviour.actions:
+                action.bind(self.output_event_queue)
 
         asyncio.create_task(self.process_input_queue())
         asyncio.create_task(self.process_output_queue())


### PR DESCRIPTION
Actions are able to change the state of the action chain for the current event, allowing actions to work together without needing to know how the other works.

In the initial scheme, each action has an incoming state, and returned and outgoing state. This required the developer of each action to remember to return the state in all code paths.

This change instead uses the object reference behaviour. As the state is a dictionary that is passed into the action, any changes in the function will automatically propagate back to the behaviour, so there is no need to return the object.