### PR TITLE
Remove 'sneaky mypy test' CI action

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -67,9 +67,6 @@ jobs:
       - name: Run PyLint
         run: pylint src examples | python .github/workflows/pylint_to_gh_action.py
 
-      - name: Sneaky mypy test
-        run: mypy --strict .
-
   lint:
     name: Run Linters
     runs-on: ubuntu-latest


### PR DESCRIPTION
This step was for testing purposes, and is already covered elsewhere in the pipeline.
Relates to #6