### PR TITLE
Linting fixes have been applied to mainline

### DIFF
--- a/examples/discord_to_desktop_notification.py
+++ b/examples/discord_to_desktop_notification.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# pylint: disable=duplicate-code
+# this is an example - duplication for emphasis is desirable
 
 from __future__ import annotations
 
@@ -79,6 +81,6 @@ class DiscordMessageToNotificationAction(Action):
             title="Someone said hello!",
             text=self._message,
         )
-        self._logger.info(f"Triggering DesktopNotification {test_event}")
+        self._logger.info("Triggering DesktopNotification %s", test_event)
 
         await self.send(test_event)

--- a/examples/trivial_discord_bot.py
+++ b/examples/trivial_discord_bot.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# pylint: disable=duplicate-code
+# this is an example - duplication for emphasis is desirable
 
 from __future__ import annotations
 

--- a/src/mewbot/bot.py
+++ b/src/mewbot/bot.py
@@ -66,8 +66,8 @@ class Bot:
         inputs = set()
 
         for connection in self._io_configs:
-            for input in connection.get_inputs():
-                inputs.add(input)
+            for con_input in connection.get_inputs():
+                inputs.add(con_input)
 
         return inputs
 

--- a/src/mewbot/io/desktop_notification.py
+++ b/src/mewbot/io/desktop_notification.py
@@ -12,6 +12,11 @@ import subprocess
 from mewbot.core import OutputEvent
 from mewbot.api.v1 import IOConfig, Input, Output
 
+try:
+    from win10toast import ToastNotifier  # type: ignore
+except ImportError:
+    ToastNotifier = None
+
 # Input for this class is theoretically possible and would be desirable - would allow mewbot to
 # trigger on an arbitrary desktop notifications.
 # Development ongoing
@@ -197,10 +202,7 @@ class DesktopNotificationOutputEngine:
         """
         Determine if we can notify and disable self if cannot
         """
-
-        try:
-            from win10toast import ToastNotifier  # type: ignore
-        except ImportError:
+        if ToastNotifier is None:
             self._logger.info(
                 "Cannot enable - chosen method requires win10toast and it's not installed"
             )
@@ -241,9 +243,7 @@ class DesktopNotificationOutputEngine:
         :param text:
         :return:
         """
-        try:
-            from win10toast import ToastNotifier
-        except ImportError:
+        if ToastNotifier is None:
             self._logger.info(
                 "Cannot display - chosen method requires win10toast and it's not installed"
             )


### PR DESCRIPTION
 - Unfortunate choice of loop variable name in bot corrected
 - win10toast importable check now done at the top of the file
 - examples marked with pylint: disable=duplicate-code - as examples, duplication for emphasis is a feature, not a bug.