### PR TITLE
Groupped dependabot updates

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.13.0
+        uses: trufflesecurity/trufflehog@v3.19.0
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@
 reuse~=1.0
 
 # Python Linting toolchain
-black~=22.8
+black~=22.12
 flake8>=5.0
 pylint>=2.14
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ types-PyYAML~=6.0
 
 # Testing toolchain
 pytest>=7.1.1
-pytest-asyncio~=0.19.0
+pytest-asyncio~=0.20.3
 pytest-cov>=3.0.0
 pytest-xdist>=2.5.0
 pytest-github-actions-annotate-failures>=0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 PyYAML~=6.0
 aiohttp>=3.8.0,<3.9.0  # Waiting for py-cord to upgrade
-setuptools~=65.4
+setuptools~=65.6
 
 # Discord Module
 py-cord~=2.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ aiohttp>=3.8.0,<3.9.0  # Waiting for py-cord to upgrade
 setuptools~=65.6
 
 # Discord Module
-py-cord~=2.1.3
+py-cord~=2.3.2
 
 # Notifications module (windows)
 win10toast~=0.9; sys_platform == "win32"

--- a/src/mewbot/api/registry.py
+++ b/src/mewbot/api/registry.py
@@ -128,9 +128,3 @@ class ComponentRegistry(abc.ABCMeta):
             return val
 
         raise ValueError(f"No API version for {component}")
-
-    @classmethod
-    def registered_classes(
-        cls, implements: ComponentKind, version: Optional[str]
-    ) -> Iterable[Type[Component]]:
-        pass

--- a/src/mewbot/api/v1.py
+++ b/src/mewbot/api/v1.py
@@ -95,6 +95,7 @@ class Input:
         self.queue = queue
 
     @staticmethod
+    @abc.abstractmethod
     def produces_inputs() -> Set[Type[InputEvent]]:
         """
         Defines the set of input events this Input class can produce.
@@ -108,12 +109,14 @@ class Input:
 
 class Output:
     @staticmethod
+    @abc.abstractmethod
     def consumes_outputs() -> Set[Type[OutputEvent]]:
         """
         Defines the set of output events that this Output class can consume
         :return:
         """
 
+    @abc.abstractmethod
     async def output(self, event: OutputEvent) -> bool:
         """
         Does the work of transmitting the event to the world.

--- a/src/mewbot/data.py
+++ b/src/mewbot/data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Union, Generic, Sequence, TypeVar
 
+import abc
 import dataclasses
 import datetime
 import enum
@@ -11,7 +12,7 @@ import enum
 DataType = TypeVar("DataType")  # pylint: disable=invalid-name
 
 
-class DataSource(Generic[DataType]):
+class DataSource(Generic[DataType], abc.ABC):
     """A source of data for use in behaviours.
     A data source can contain any number of items with a common primitive type.
 
@@ -20,6 +21,7 @@ class DataSource(Generic[DataType]):
     thereof.
     """
 
+    @abc.abstractmethod
     def get(self) -> DataType:
         """Returns an item in this Source. The source can choose if this is the
         first item, a random item, or the next in the iteration of this source (or
@@ -28,6 +30,7 @@ class DataSource(Generic[DataType]):
         store for this source, or a DataSourceEmpty exception if there is no data
         to return."""
 
+    @abc.abstractmethod
     def __len__(self) -> int:
         """Returns the number of items in this DataStore.
 
@@ -36,6 +39,7 @@ class DataSource(Generic[DataType]):
         (for sources that work like dictionary) or the maximum slice value
         (for sources that work like a sequence)."""
 
+    @abc.abstractmethod
     def __getitem__(self, key: Union[int, str]) -> DataType:
         """Allows access to a value in this DataStore via a key.
         If key is of an inappropriate type, TypeError may be raised;
@@ -44,9 +48,11 @@ class DataSource(Generic[DataType]):
         For mapping types, if key is missing (not in the container),
         KeyError should be raised."""
 
+    @abc.abstractmethod
     def keys(self) -> Sequence[str]:
         """All the keys for a dictionary accessed source."""
 
+    @abc.abstractmethod
     def random(self) -> DataType:
         """Gets a random item from this source."""
 


### PR DESCRIPTION
Updates:
- setuptools from ~=65.4 to ~=65.6
- pytest-asyncio from ~=0.19.0 to ~=0.20.3
- py-cord from ~=2.1.3 to ~=2.3.2
- black from ~=22.8 to ~=22.12
- trufflesecurity/trufflehog from 3.13.0 to 3.19.0