### PR TITLE
Add SPDX license information to all existing files.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 version: 2
 updates:
   - package-ecosystem: "pip"

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 name: Auto-Review
 
 on:

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 name: Trufflehog
 
 on: push

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Benedict Harcourt <ben.harcourt@harcourtprogramming.co.uk>
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
 #
-# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-License-Identifier: CC0-1.0
 
 # Caching directories
 /.local/

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,10 +1,8 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: mewbot
-Upstream-Contact: Benedict Harcourt <ben.harcourt@harcourtprogramming.co.uk>
-Source: https://github.com/javajawa/mewbot
+Upstream-Contact: Mewbot Developers <mewbot@quicksilver.london>
+Source: https://github.com/mewler/mewbot
 
-# Sample paragraph, commented out:
-#
-# Files: src/*
-# Copyright: $YEAR $NAME <$CONTACT>
-# License: ...
+Files: *
+Copyright: 2023 Mewbot Developers <mewbot@quicksilver.london>
+License: BSD-2-Clause

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -66,7 +66,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-mewbot@tea-cats.co.uk.
+mewbot@quicksilver.london.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,6 @@
 <!--
+SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+
 SPDX-License-Identifier: CC-BY-4.0
 -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,17 @@ If you want to start on a piece of work:
 If another user has the assignment, reach out to them and see if you can help;
 coordination is the key to success in open source development.
 
+## Licensing Policy
+
+We ask that code created for the Mewbot project is transferred to the projects'
+ownership; this is noted as the copyright being held by
+> Mewbot Developers <mewbot@quicksilver.london>
+
+BSD-2-Clause licenses are used for code, Creative Commons v4 for prose (documentation
+and examples). For completeness with the [SPDX](https://spdx.dev/) spec, files which
+have no meaningfully ownable content (generated lock files, gitignore files, etc.),
+as per [the reuse.software recommendation](https://reuse.software/faq/#uncopyrightable).
+
 ## Code Style
 
 Coding tackles the thorny problem of trying to express logical, computational concepts in a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Contributing
 
 Contributions to this project are welcome, whether minor updates to documentation or entirely new features.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Contributors
 
 Thanks goes to everyone who has contributed to the project

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--
-SPDX-FileCopyrightText: 2021 Benedict Harcourt <ben.harcourt@harcourtprogramming.co.uk>
+SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
 
-SPDX-License-Identifier: BSD-2-Clause
+SPDX-License-Identifier: CC-BY-4.0
 -->
 
 # MewBot

--- a/design-docs/README.md
+++ b/design-docs/README.md
@@ -1,7 +1,7 @@
 <!--
-SPDX-FileCopyrightText: 2021 Benedict Harcourt <ben.harcourt@harcourtprogramming.co.uk>
+SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
 
-SPDX-License-Identifier: BSD-2-Clause
+SPDX-License-Identifier: CC-BY-4.0
 -->
 
 # Kitteh's Bot Framework/Infrastructure

--- a/design-docs/data-flow.md
+++ b/design-docs/data-flow.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Data Flow
 
 ```

--- a/design-docs/data.md
+++ b/design-docs/data.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Data Storage
 
 A lot of bot functionality relies on persistent or external data;

--- a/design-docs/vision.md
+++ b/design-docs/vision.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Vision
 
 The purpose of mew bot is to create an open-source infrastructure for building

--- a/dev-docs/io-dev-notes/discord-dev-notes.md
+++ b/dev-docs/io-dev-notes/discord-dev-notes.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
 
 ### Why am I getting blank events when messages are sent in channels the bot is monitoring?
 

--- a/examples/discord_bots/delete_warn_discord_bot.yaml
+++ b/examples/discord_bots/delete_warn_discord_bot.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
 kind: IOConfig
 implementation: mewbot.io.discord.DiscordIO
 uuid: aaaaaaaa-aaaa-4aaa-0001-aaaaaaaaaa00

--- a/examples/discord_bots/discord_to_desktop_notification.yaml
+++ b/examples/discord_bots/discord_to_desktop_notification.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
 kind: IOConfig
 implementation: mewbot.io.discord.DiscordIO
 uuid: aaaaaaaa-aaaa-4aaa-0000-aaaaaaaaaa00

--- a/examples/discord_bots/editor_warn_discord_bot.yaml
+++ b/examples/discord_bots/editor_warn_discord_bot.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
 kind: IOConfig
 implementation: mewbot.io.discord.DiscordIO
 uuid: aaaaaaaa-aaaa-4aaa-0001-aaaaaaaaaa00

--- a/examples/discord_bots/history_discord_bot.yaml
+++ b/examples/discord_bots/history_discord_bot.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
 kind: IOConfig
 implementation: mewbot.io.discord.DiscordIO
 uuid: aaaaaaaa-aaaa-4aaa-0001-aaaaaaaaaa00

--- a/examples/discord_bots/trivial_discord_bot.yaml
+++ b/examples/discord_bots/trivial_discord_bot.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
 kind: IOConfig
 implementation: mewbot.io.discord.DiscordIO
 uuid: aaaaaaaa-aaaa-4aaa-0001-aaaaaaaaaa00

--- a/examples/rss_input.yaml
+++ b/examples/rss_input.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
 kind: IOConfig
 implementation: mewbot.io.rss.RSSIO
 uuid: aaaaaaaa-aaaa-4aaa-0000-aaaaaaaaaa00

--- a/examples/trivial_http_post.yaml
+++ b/examples/trivial_http_post.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
 kind: IOConfig
 implementation: mewbot.io.http.HTTPServlet
 uuid: aaaaaaaa-aaaa-4aaa-0002-aaaaaaaaaa00

--- a/examples/trivial_socket.yaml
+++ b/examples/trivial_socket.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
 kind: IOConfig
 implementation: mewbot.io.socket.SocketIO
 uuid: aaaaaaaa-aaaa-4aaa-0003-aaaaaaaaaa00

--- a/mewbot.svg.license
+++ b/mewbot.svg.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
-# SPDX-FileCopyrightText: 2020-2021 Benedict Harcourt <ben.harcourt@harcourtprogramming.co.uk>
+# Python project info
+
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+;
+; SPDX-License-Identifier: CC0-1.0
+
 # pytest.ini
 [pytest]
 asyncio_mode = auto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Benedict Harcourt <ben.harcourt@harcourtprogramming.co.uk>
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Benedict Harcourt <ben.harcourt@harcourtprogramming.co.uk>
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ with open("LICENSE.md", "r", encoding="utf-8") as lf:
 setuptools.setup(
     name="mewbot",
     version="0.0.1",
-    author="Benedict Harcourt & Alex Cameron",
-    author_email="mewbot@tea-cats.co.uk & mewbot@quicksilver.london",
+    author="Mewbot Developers (https://github.com/mewler)",
+    author_email="mewbot@quicksilver.london",
     description="Lightweight, YAML-driven, text based, generic irc Bot framework",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 import setuptools  # type: ignore
 
 with open("README.md", "r", encoding="utf-8") as rmf:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 sonar.projectName=mewbot
 sonar.organization=mewler
 

--- a/src/examples/__init__.py
+++ b/src/examples/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause

--- a/src/examples/__main__.py
+++ b/src/examples/__main__.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 import sys

--- a/src/examples/discord_bots/delete_warn_discord_bot.py
+++ b/src/examples/discord_bots/delete_warn_discord_bot.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 # pylint: disable=duplicate-code
 # this is an example - duplication for emphasis is desirable
 # Aims to expose the full capabilities of this discord bot framework

--- a/src/examples/discord_bots/discord_to_desktop_notification.py
+++ b/src/examples/discord_bots/discord_to_desktop_notification.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 # pylint: disable=duplicate-code
 # this is an example - duplication for emphasis is desirable
 

--- a/src/examples/discord_bots/editor_warn_discord_bot.py
+++ b/src/examples/discord_bots/editor_warn_discord_bot.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 # pylint: disable=duplicate-code
 # this is an example - duplication for emphasis is desirable
 # Aims to expose the full capabilities of this discord bot framework

--- a/src/examples/discord_bots/history_discord_bot.py
+++ b/src/examples/discord_bots/history_discord_bot.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 # pylint: disable=duplicate-code
 # this is an example - duplication for emphasis is desirable
 # Aims to expose the full capabilities of this discord bot framework

--- a/src/examples/discord_bots/trivial_discord_bot.py
+++ b/src/examples/discord_bots/trivial_discord_bot.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 # pylint: disable=duplicate-code
 # this is an example - duplication for emphasis is desirable
 # A minimum viable discord bot - which just responds with a set message to every input

--- a/src/examples/rss_input.py
+++ b/src/examples/rss_input.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 # pylint: disable=duplicate-code
 # this is an example - duplication for emphasis is desirable
 

--- a/src/examples/yaml_bot.py
+++ b/src/examples/yaml_bot.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from mewbot.demo import Foo

--- a/src/mewbot/__init__.py
+++ b/src/mewbot/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause

--- a/src/mewbot/api/__init__.py
+++ b/src/mewbot/api/__init__.py
@@ -1,1 +1,5 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause

--- a/src/mewbot/api/registry.py
+++ b/src/mewbot/api/registry.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Tooling for recording the creation of implementation classes, allowing
 for lists """
 

--- a/src/mewbot/api/v1.py
+++ b/src/mewbot/api/v1.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import (

--- a/src/mewbot/bot.py
+++ b/src/mewbot/bot.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Set, Type, Callable

--- a/src/mewbot/core/__init__.py
+++ b/src/mewbot/core/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-#
+
 # SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
 #
 # SPDX-License-Identifier: BSD-2-Clause

--- a/src/mewbot/core/componentSchema.yaml
+++ b/src/mewbot/core/componentSchema.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
 #
-# SPDX-License-Identifier: CC-BY-4.0
+# SPDX-License-Identifier: BSD-2-Clause
 
 $schema: http://json-schema.org/draft-07/schema
 $id: https://mewbot.com/schema.xml

--- a/src/mewbot/core/componentSchema.yaml
+++ b/src/mewbot/core/componentSchema.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
 $schema: http://json-schema.org/draft-07/schema
 $id: https://mewbot.com/schema.xml
 title: Mewbot Components

--- a/src/mewbot/data.py
+++ b/src/mewbot/data.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import Union, Generic, Sequence, TypeVar

--- a/src/mewbot/demo.py
+++ b/src/mewbot/demo.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import Set, Type, Dict, Any

--- a/src/mewbot/io/__init__.py
+++ b/src/mewbot/io/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Benedict Harcourt <ben.harcourt@harcourtprogramming.co.uk>
+#
+# SPDX-License-Identifier: BSD-2-Clause

--- a/src/mewbot/io/desktop_notification.py
+++ b/src/mewbot/io/desktop_notification.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import Optional, Set, Sequence, Type, Any

--- a/src/mewbot/io/discord.py
+++ b/src/mewbot/io/discord.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import Optional, Set, Sequence, Type, List

--- a/src/mewbot/io/http.py
+++ b/src/mewbot/io/http.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 """
 When defining a new IOConfig, you need to define the components for it
 

--- a/src/mewbot/io/rss.py
+++ b/src/mewbot/io/rss.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import (

--- a/src/mewbot/io/socket.py
+++ b/src/mewbot/io/socket.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import Optional, Sequence, Set, Type

--- a/src/mewbot/loader.py
+++ b/src/mewbot/loader.py
@@ -1,5 +1,9 @@
 #!/use/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import Any, TextIO, Type

--- a/src/mewbot/tools/__init__.py
+++ b/src/mewbot/tools/__init__.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Development tools and helpers"""
 
 from __future__ import annotations

--- a/src/mewbot/tools/lint.py
+++ b/src/mewbot/tools/lint.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import Generator, Set

--- a/src/mewbot/tools/test.py
+++ b/src/mewbot/tools/test.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import List, Generator

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import Generic, Optional, Type, TypeVar

--- a/tests/io/test_io_discord.py
+++ b/tests/io/test_io_discord.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Loads a file in, sees if it works
 
 from __future__ import annotations

--- a/tests/io/test_io_http_socket.py
+++ b/tests/io/test_io_http_socket.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Unified test of http and socket parts of mewbot.io
 # Loads a file in, sees if it works, and then probes the socket and http class.
 

--- a/tests/io/test_io_rss.py
+++ b/tests/io/test_io_rss.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from typing import Type
 
 import asyncio

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 from typing import Type

--- a/tools/reuse
+++ b/tools/reuse
@@ -5,14 +5,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 COPYRIGHT="Mewbot Developers <mewbot@quicksilver.london>"
-
 LICENSE="BSD-2-Clause"
 
-find . \
-	-path './.git' -prune -o \
-	-path './.reuse' -prune -o \
-	-path './LICENSES' -prune -o \
-	-path './venv' -prune -o \
-	-type f \
-	-exec \
-reuse addheader --merge-copyrights --copyright "$COPYRIGHT" --license "$LICENSE" --skip-unrecognised '{}' +
+reuse annotate --merge-copyrights --copyright "$COPYRIGHT" --license "$LICENSE" --skip-unrecognised --skip-existing --recursive .

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+;
+; SPDX-License-Identifier: BSD-2-Clause
+
 # SPDX-FileCopyrightText: 2020 Benedict Harcourt <ben.harcourt@harcourtprogramming.co.uk>
 #
 # SPDX-License-Identifier: CC0-1.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,6 @@
 ;
 ; SPDX-License-Identifier: BSD-2-Clause
 
-# SPDX-FileCopyrightText: 2020 Benedict Harcourt <ben.harcourt@harcourtprogramming.co.uk>
-#
-# SPDX-License-Identifier: CC0-1.0
-
 [flake8]
 max-complexity = 8
 max-line-length = 100


### PR DESCRIPTION
This removes my own name from a bunch of license info, and is a step in the right direction for having (`reuse`)[https://reuse.software/] be a functional part of the toolchain.

Marked as draft because:
 - Docs should probably be a CC-based license, as they are not 'code'
 - The example YAML files might also benefit from that.