### PR TITLE
Add MacOS, Windows, and python 3.11 to auto review

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 name: Auto-Review
+run-name: "Automated code review for \"${{ github.head_ref }}\""
 
 on:
   push:
@@ -18,6 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # Which version of the reports Sonar receives.
+  DEFAULT_OS: ubuntu-latest
   DEFAULT_PYTHON: 3.9
 
 jobs:
@@ -53,11 +56,12 @@ jobs:
 
   test:
     name: Test Python code
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        version: ["3.9", "3.10"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        version: ["3.9", "3.10", "3.11"]
       fail-fast: false
 
     steps:
@@ -77,14 +81,26 @@ jobs:
         run:  pip install -r requirements-dev.txt
 
       - name: Run Tests
+        shell: bash
         run: ./tools/test --cov
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: test-results-${{ matrix.version }}
+          name: test-results-${{ matrix.os }}-${{ matrix.version }}
           path: reports
+
+  tests-passed:
+    name: Tests Passed
+    runs-on: ubuntu-latest
+
+    needs:
+      - test
+
+    steps:
+      - name: Mark all test runs as successful
+        run: /bin/true
 
   sonarcloud:
     name: SonarCloud
@@ -112,7 +128,7 @@ jobs:
         uses: actions/download-artifact@v3
         if: always()
         with:
-          name: test-results-${{ env.DEFAULT_PYTHON }}
+          name: test-results-${{ env.DEFAULT_OS }}-${{ env.DEFAULT_PYTHON }}
           path: reports
 
       - name: SonarCloud Scan

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 name: Trufflehog
+run-name: "Checking for secrets in \"${{ github.ref }}\""
 
 on: push
 

--- a/src/mewbot/tools/path.py
+++ b/src/mewbot/tools/path.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+from typing import List
+
+import os
+
+
+def gather_paths() -> List[str]:
+    return ["./src", "./test"]
+
+
+if __name__ == "__main__":
+    print(os.pathsep.join(gather_paths()))

--- a/tools/path
+++ b/tools/path
@@ -7,5 +7,5 @@
 PYTHON=${PYTHON:-python3}
 readonly PYTHON
 
-PYTHONPATH="./src:./test"
+PYTHONPATH="$("$PYTHON" src/mewbot/tools/path.py)"
 export PYTHONPATH


### PR DESCRIPTION
GitHub is now configured to lint on python versions 3.9 through 3.11 on the current versions of Windows Server, MacOS, and Ubuntu Linux.