### PR TITLE
tools: Configure to work with any src-dir projects

### DIFF
--- a/src/mewbot/tools/__init__.py
+++ b/src/mewbot/tools/__init__.py
@@ -4,22 +4,26 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-"""Development tools and helpers"""
+"""Development tools and helpers."""
 
 from __future__ import annotations
 
 import abc
-import os
-from typing import Generator, List, Set
-
 import dataclasses
+import os
 import subprocess
 import sys
+
+from collections.abc import Iterable
+
+from .path import gather_paths
 
 
 @dataclasses.dataclass
 class Annotation:
-    """Schema for a GitHub action annotation, representing an error"""
+    """
+    Schema for a GitHub action annotation, representing an error.
+    """
 
     level: str
     file: str
@@ -29,6 +33,8 @@ class Annotation:
     message: str
 
     def __str__(self) -> str:
+        """Outputs annotations in the format used in GitHub Actions checker."""
+
         mess = self.message.replace("\n", "%0A")
         return (
             f"::{self.level} file={self.file},line={self.line},"
@@ -36,6 +42,8 @@ class Annotation:
         )
 
     def __lt__(self, other: Annotation) -> bool:
+        """Sorts annotations by file path and then line number."""
+
         if not isinstance(other, Annotation):
             return False
 
@@ -43,18 +51,36 @@ class Annotation:
 
 
 class ToolChain(abc.ABC):
-    """Wrapper class for running linting tools, and outputting GitHub annotations"""
+    """
+    Support class for running a series of tools across the codebase.
 
-    folders: Set[str]
+    Each tool will be given the same set of folders, and can produce output
+    to the console and/or 'annotations' indicating issues with the code.
+
+    The behaviour of this class alters based whether it is being run in 'CI mode'.
+    This mode disables all interactive and automated features of the toolchain,
+    and instead outputs the state through a series of 'annotations', each one
+    representing an issue the tools found.
+    """
+
+    folders: set[str]
     is_ci: bool
     success: bool
 
     def __init__(self, *folders: str, in_ci: bool) -> None:
+        """
+        Sets up a tool chain with the given settings.
+
+        :param folders: The list of folders to run this tool against
+        :param in_ci: Whether this is a run being called from a CI pipeline
+        """
         self.folders = set(folders)
         self.is_ci = in_ci
         self.success = True
 
     def __call__(self) -> None:
+        """Runs the tool chain, including exiting the script with an appropriate status code."""
+        # Ensure the reporting location exists.
         if not os.path.exists("./reports"):
             os.mkdir("./reports")
 
@@ -66,11 +92,33 @@ class ToolChain(abc.ABC):
         sys.exit(not self.success or len(issues) > 0)
 
     @abc.abstractmethod
-    def run(self) -> Generator[Annotation, None, None]:
-        """Abstract function for this tool chain to run its checks"""
+    def run(self) -> Iterable[Annotation]:
+        """
+        Abstract function for this tool chain to run its checks.
+
+        The function can call any number of sub-tools.
+        It should set `success` to false if any tool errors or raises issues.
+
+        When in CI mode, any issues the tool finds should be returned as Annotations.
+        These will then be reported back to the CI runner.
+
+        Outside of CI mode, the toolchain can take the action it deems most appropriate,
+        including pretty messages to the user, automatically fixing, or still using annotations.
+        """
 
     def run_tool(self, name: str, *args: str) -> subprocess.CompletedProcess[bytes]:
-        """Helper function to run an external binary as a check"""
+        """
+        Helper function to run an external program as a check.
+
+        The program will have the list of folders appended to the supplied arguments.
+        If the process has a non-zero exit code, success is set to False for the chain.
+
+        When in CI mode, this function returns the process result (including stdout and stderr),
+        along with storing copies in the reports/ folder.
+
+        :param name: The user-friendly name of the tools
+        :param args: The command line to use. The first value should be the executable path.
+        """
 
         arg_list = list(args)
         arg_list.extend(self.folders)
@@ -82,8 +130,24 @@ class ToolChain(abc.ABC):
         return run_result
 
     def _run_utility(
-        self, name: str, arg_list: List[str]
+        self, name: str, arg_list: list[str]
     ) -> subprocess.CompletedProcess[bytes]:
+        """
+        Helper function to run an external program as a check.
+
+        Outside of CI, the command will be given direct access to stdout/stderr and left to
+        its default behaviour.
+
+        Inside of CI, a block/group will be opened to contain the scripts output, and that
+        output will be captured. Additionally, the output will be added to the reports/ folder.
+
+        That output will also be returned to the calling code, allowing it to parse the output
+        (or any generated artifacts) and emit annotations for any issues that have been found.
+
+        :param name: The user-friendly name of the tools
+        :param arg_list: The command line to use. The first value should be the executable path.
+        """
+
         run = subprocess.run(
             arg_list, stdin=subprocess.DEVNULL, capture_output=self.is_ci, check=False
         )
@@ -103,8 +167,13 @@ class ToolChain(abc.ABC):
         return run
 
     @staticmethod
-    def github_list(issues: List[Annotation]) -> None:
-        """Outputs the annotations in the format for GitHub actions."""
+    def github_list(issues: list[Annotation]) -> None:
+        """
+        Outputs the annotations in the format for GitHub actions.
+
+        These are presented as group at the end of output as a work-around for
+        the limit of 10 annotations per check run actually being shown on a commit or merge.
+        """
 
         print("::group::Annotations")
         for issue in sorted(issues):
@@ -112,3 +181,6 @@ class ToolChain(abc.ABC):
         print("::endgroup::")
 
         print("Total Issues:", len(issues))
+
+
+__all__ = ["Annotation", "ToolChain", "gather_paths"]

--- a/src/mewbot/tools/path.py
+++ b/src/mewbot/tools/path.py
@@ -4,14 +4,43 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-from typing import List
+"""
+Tools for detecting paths at which source files are installed.
+
+This file, when called directly, prints out a set of values for PYTHONPATH.
+As such, it can not rely on anything that would be loaded using PYTHONPATH,
+i.e. we can not use any other mewbot code from this file.
+"""
+
+from collections.abc import Iterable
 
 import os
+import pathlib
 
 
-def gather_paths() -> List[str]:
-    return ["./src", "./test"]
+def scan_paths(
+    root: pathlib.Path, *filters: str, recursive: bool = True
+) -> Iterable[pathlib.Path]:
+    """Scan for folders with a given name in the provided path."""
+
+    if not recursive:
+        yield from [root / name for name in filters if (root / name).exists()]
+        return
+
+    for path, children, _ in os.walk(root):
+        for name in filters:
+            if name in children:
+                yield pathlib.Path(path) / name
+
+
+def gather_paths(*filters: str) -> Iterable[str]:
+    """Locates all folders with the given names in this project's code locations."""
+
+    root = pathlib.Path(os.curdir)
+
+    return (str(x.absolute()) for x in scan_paths(root, *filters, recursive=False))
 
 
 if __name__ == "__main__":
-    print(os.pathsep.join(gather_paths()))
+    # When called directly, this module output the value of the PYPATH environment variable
+    print(os.pathsep.join(gather_paths("src")))


### PR DESCRIPTION
This change is the first step for introducing the concepts of both `mebot.tools` as an external package which can be pulled in to lint another codebase (such as a mewbot plugin), and for restructuring the repository to have in-tree plugins.

The change adds the capability for `mewbot.tools.path` to dynamically generate paths by looking for folders matching a certain name in a given location. Currently it looks only in `.`, but this can easily be expanded.

Along with these changes, the ability to filter what paths are examined by the paths has been added, with both the `lint` and `test` tool chains taking a list of paths to run against, and the `test` tools also supporting a list of coverage references being selected.

This allows for easier checking of the state of a specific module. For example

```sh
./tools/test tests/io/test_io_rss.py --cover mewbot.io.rss
```

Will run only one test file, and produce a coverage report for a single class. This should reduce testing times when working locally on a specific component.

Additionally, the entire module's documentation has been updated.