### PR TITLE
tools: Begin pydocstyle setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,13 @@ unsafe-load-any-extension = "no"
 
 jobs=1
 
+[tool.pydocstyle]
+
+convention="pep257"
+add-ignore=["D200", "D202", "D401"]
+add-select=["D204", "D213", "D416", "D417"]
+ignore-self-only-init=true
+
 [tool.pylint."MESSAGES CONTROL"]
 
 disable=[


### PR DESCRIPTION
Adds the configuration for pydocstyle to the pyproject.toml, ready for users to test their documentation against. MewBot's documentation is not yet complete enough to include it in the main linting toolchain (or to re-enable the related errors in pylint).

The meaning of the values can be seen in http://www.pydocstyle.org/en/stable/error_codes.html. We import the original PEP 257 standard, with modifications:
 - Disable `D202`, Enable `D204` -> Require one blank line after doc block.
 - Enable `D213`, Disable `D200` -> Start blocks on the second line (fist line is just `"""`). Summary only doc strings may be on one line
 - Disable `D401` -> Summary is not required to be in the 'imperative mood'
 - Enable `D417` - > Require documenting arguments
 - Enable `D416` -> Section name should end with a colon