### PR TITLE
actions: Only lint merge files that have changed

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 100
 
       - name: Setup Python ${{ env.DEFAULT_PYTHON }}
         uses: actions/setup-python@v4
@@ -42,7 +44,13 @@ jobs:
         run:  pip install -r requirements-dev.txt
 
       - name: Run Linters
-        run: ./tools/lint
+        run: |
+          if [ -n "${{ github.event.pull_request.base.sha }}" ]
+          then
+            git diff --name-only --diff-filter=ACMRT "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" | grep '.py$' | xargs ./tools/lint
+          else
+            ./tools/lint
+          fi
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
When running in a merge request context, we only need to run the linters against the changed files. This aligns better with the Sonar concept of not penalising merge requests for code they have not changed, and will allow for easier enabling of new linting tools (such as documentation requirements).