### PR TITLE
actions: Run documentation lint on change files in merge requests

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -51,6 +51,36 @@ jobs:
           name: lint-results
           path: reports
 
+  doc-lint:
+    name: Lint Python documentation
+    runs-on: ubuntu-latest
+
+    if: ${{ github.event_name == 'pull_request' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 100
+
+      - name: Setup Python ${{ env.DEFAULT_PYTHON }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run:  pip install -r requirements-dev.txt
+
+      - name: Run PyDocStyle
+        run: >
+          git diff --name-only --diff-filter=ACMRT
+          "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" |
+          grep '.py$' | xargs --no-run-if-empty pydocstyle
+
   test:
     name: Test Python code
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
As it currently stands, we want to improve our documentation, but having one merge to fix all the documentation issues will stall development. That project will begin, but we can start enforcing the documentation requirements on all new code.