### PR TITLE
Refactor output queue

### DIFF
--- a/examples/rss_input.yaml
+++ b/examples/rss_input.yaml
@@ -18,11 +18,11 @@ properties:
   name: 'RSS Printer'
 triggers:
   - kind: Trigger
-    implementation: mewbot.demo.AllEventTrigger
+    implementation: mewbot.io.common.AllEventTrigger
     uuid: aaaaaaaa-aaaa-4aaa-0000-aaaaaaaaaa03
     properties: { }
   - kind: Trigger
-    implementation: mewbot.demo.AllEventTrigger
+    implementation: mewbot.io.common.AllEventTrigger
     uuid: aaaaaaaa-aaaa-4aaa-0000-aaaaaaaaaa04
     properties: { }
 conditions: []

--- a/examples/trivial_http_post.yaml
+++ b/examples/trivial_http_post.yaml
@@ -18,12 +18,12 @@ properties:
   name: 'Echo Inputs'
 triggers:
   - kind: Trigger
-    implementation: mewbot.demo.AllEventTrigger
+    implementation: mewbot.io.common.AllEventTrigger
     uuid: aaaaaaaa-aaaa-4aaa-0002-aaaaaaaaaa02
     properties: { }
 conditions: []
 actions:
   - kind: Action
-    implementation: mewbot.demo.PrintAction
+    implementation: mewbot.io.common.PrintAction
     uuid: aaaaaaaa-aaaa-4aaa-0002-aaaaaaaaaa03
     properties: { }

--- a/examples/trivial_socket.yaml
+++ b/examples/trivial_socket.yaml
@@ -18,12 +18,12 @@ properties:
   name: 'Echo Inputs'
 triggers:
   - kind: Trigger
-    implementation: mewbot.demo.AllEventTrigger
+    implementation: mewbot.io.common.AllEventTrigger
     uuid: aaaaaaaa-aaaa-4aaa-0003-aaaaaaaaaa02
     properties: { }
 conditions: []
 actions:
   - kind: Action
-    implementation: mewbot.demo.PrintAction
+    implementation: mewbot.io.common.PrintAction
     uuid: aaaaaaaa-aaaa-4aaa-0003-aaaaaaaaaa03
     properties: { }

--- a/plugins/mewbot-io-discord/src/examples/discord_bots/delete_warn_discord_bot.py
+++ b/plugins/mewbot-io-discord/src/examples/discord_bots/delete_warn_discord_bot.py
@@ -20,7 +20,7 @@ provided.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Set, Type
+from typing import Any, AsyncIterable, Dict, Set, Type
 
 import logging
 
@@ -105,17 +105,20 @@ class DiscordDeleteResponseAction(Action):
     def message(self, message: str) -> None:
         self._message = str(message)
 
-    async def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
+    async def act(
+        self, event: InputEvent, state: Dict[str, Any]
+    ) -> AsyncIterable[OutputEvent]:
         """
         Construct a DiscordOutputEvent with the result of performing the calculation.
         """
-        if isinstance(event, DiscordMessageDeleteInputEvent):
-            self._logger.info("We have detected deleting! - %s", event)
-            test_event = DiscordOutputEvent(
-                text=f'User {event.message.author} has deleted message: "{event.message.content}"',
-                message=event.message,
-                use_message_channel=True,
-            )
-            await self.send(test_event)
+        if not isinstance(event, DiscordMessageDeleteInputEvent):
+            self._logger.warning("Received wrong event type %s", type(event))
+            return
 
-        self._logger.warning("Received wrong event type %s", type(event))
+        self._logger.info("We have detected deleting! - %s", event)
+        test_event = DiscordOutputEvent(
+            text=f'User {event.message.author} has deleted message: "{event.message.content}"',
+            message=event.message,
+            use_message_channel=True,
+        )
+        yield test_event

--- a/plugins/mewbot-io-discord/src/examples/discord_bots/discord_to_desktop_notification.py
+++ b/plugins/mewbot-io-discord/src/examples/discord_bots/discord_to_desktop_notification.py
@@ -16,7 +16,7 @@ is detected in any of the channels which this bot has access to.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Set, Type
+from typing import Any, AsyncIterable, Dict, Set, Type
 
 import logging
 
@@ -123,7 +123,9 @@ class DiscordMessageToNotificationAction(Action):
     def message(self, message: str) -> None:
         self._message = str(message)
 
-    async def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
+    async def act(
+        self, event: InputEvent, state: Dict[str, Any]
+    ) -> AsyncIterable[OutputEvent]:
         """
         Construct a DiscordOutputEvent with the result of performing the calculation.
         """
@@ -137,4 +139,4 @@ class DiscordMessageToNotificationAction(Action):
         )
         self._logger.info("Triggering DesktopNotification %s", test_event)
 
-        await self.send(test_event)
+        yield test_event

--- a/plugins/mewbot-io-discord/src/examples/discord_bots/editor_warn_discord_bot.py
+++ b/plugins/mewbot-io-discord/src/examples/discord_bots/editor_warn_discord_bot.py
@@ -19,7 +19,7 @@ provided, along with the current contents of the message.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Set, Type
+from typing import Any, AsyncIterable, Dict, Set, Type
 
 import logging
 
@@ -98,18 +98,21 @@ class DiscordEditResponse(Action):
     def message(self, message: str) -> None:
         self._message = str(message)
 
-    async def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
+    async def act(
+        self, event: InputEvent, state: Dict[str, Any]
+    ) -> AsyncIterable[OutputEvent]:
         """
         Construct a DiscordOutputEvent with the result of performing the calculation.
         """
-        if isinstance(event, DiscordMessageEditInputEvent):
-            self._logger.info("We have detected editing! - %s", event)
-            test_event = DiscordOutputEvent(
-                text=f'We have detected editing! "{event.message_before.content}"'
-                f' was changed to "f{event.message_after.content}"',
-                message=event.message_after,
-                use_message_channel=True,
-            )
-            await self.send(test_event)
+        if not isinstance(event, DiscordMessageEditInputEvent):
+            self._logger.warning("Received wrong event type %s", type(event))
+            return
 
-        self._logger.warning("Received wrong event type %s", type(event))
+        self._logger.info("We have detected editing! - %s", event)
+        test_event = DiscordOutputEvent(
+            text=f'We have detected editing! "{event.message_before.content}"'
+            f' was changed to "f{event.message_after.content}"',
+            message=event.message_after,
+            use_message_channel=True,
+        )
+        yield test_event

--- a/plugins/mewbot-io-discord/src/examples/discord_bots/history_discord_bot.py
+++ b/plugins/mewbot-io-discord/src/examples/discord_bots/history_discord_bot.py
@@ -19,7 +19,7 @@ Note - would be nice to set a number per channel as well as a global number.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Set, Type
+from typing import Any, Dict, Set, Type, AsyncIterable
 
 import logging
 
@@ -116,8 +116,9 @@ class DiscordPrintAction(Action):
     def message(self, message: str) -> None:
         self._message = str(message)
 
-    async def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
+    async def act(self, event: InputEvent, state: Dict[str, Any]) -> AsyncIterable[None]:
         """
         Construct a DiscordOutputEvent with the result of performing the calculation.
         """
         print(event)
+        yield None

--- a/plugins/mewbot-io-discord/src/examples/discord_bots/trivial_discord_bot.py
+++ b/plugins/mewbot-io-discord/src/examples/discord_bots/trivial_discord_bot.py
@@ -19,7 +19,7 @@ string also given in the yaml.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Set, Type
+from typing import Any, AsyncIterable, Dict, Set, Type
 
 import logging
 
@@ -116,7 +116,9 @@ class DiscordCommandTextResponse(Action):
     def message(self, message: str) -> None:
         self._message = str(message)
 
-    async def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
+    async def act(
+        self, event: InputEvent, state: Dict[str, Any]
+    ) -> AsyncIterable[OutputEvent]:
         """
         Construct a DiscordOutputEvent with the result of performing the calculation.
         """
@@ -128,4 +130,4 @@ class DiscordCommandTextResponse(Action):
             text=self._message, message=event.message, use_message_channel=True
         )
 
-        await self.send(test_event)
+        yield test_event

--- a/src/examples/rss_input.py
+++ b/src/examples/rss_input.py
@@ -15,7 +15,7 @@ Utility methods to support the rss_input example.
 An IOConfig for driving behavior based off RSS feeds.
 """
 
-from typing import Any, Dict, Set, Type
+from typing import Any, AsyncIterable, Dict, Set, Type
 
 from mewbot.api.v1 import Action
 from mewbot.core import InputEvent, OutputEvent
@@ -41,7 +41,7 @@ class RSSPrintAction(Action):
         """
         return set()
 
-    async def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
+    async def act(self, event: InputEvent, state: Dict[str, Any]) -> AsyncIterable[None]:
         """
         Acts on events pulled from the queue.
 
@@ -57,3 +57,4 @@ class RSSPrintAction(Action):
         rss_output_str.append(f"New event ... event - \n{event}")
 
         print("\n".join(rss_output_str))
+        yield None

--- a/src/examples/yaml_bot.py
+++ b/src/examples/yaml_bot.py
@@ -10,7 +10,7 @@ Basic example of how to load a mewbot component from yaml.
 
 from __future__ import annotations
 
-from mewbot.demo import Foo
+from mewbot.io.common import ReplyAction
 from mewbot.loader import load_component
 
 

--- a/src/examples/yaml_bot.py
+++ b/src/examples/yaml_bot.py
@@ -27,18 +27,18 @@ def main() -> None:
     """
     yaml_demo = load_component(
         {
-            "kind": "Condition",
-            "implementation": "mewbot.demo.Foo",
+            "kind": "Action",
+            "implementation": "mewbot.io.common.ReplyAction",
             "uuid": "3f7c493b-ce05-4566-b906-54ece62804c1",
-            "properties": {"channel": "cat"},
+            "properties": {"message": "Hello, World!"},
         }
     )
 
-    local_demo = Foo()
-    local_demo.channel = "cat"
+    local_demo = ReplyAction()
+    local_demo.message = "Hello, World!"
 
     print("Loaded from YAML-like object:  ", yaml_demo)
-    print("Created and channel set        ", local_demo)
+    print("Created and message set        ", local_demo)
     print("Serialised:                    ", local_demo.serialise())
     print("Re-loaded from serialized data:", load_component(local_demo.serialise()))
 

--- a/src/mewbot/bot.py
+++ b/src/mewbot/bot.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Set, Type, Callable
 
 import asyncio
-import itertools
 import logging
 import signal
 
@@ -277,11 +276,6 @@ class BotRunner:
         """
         input_tasks: List[asyncio.Task[None]] = []
 
-        # Startup the outputs - which are contained in the behaviors
-        for behaviour in itertools.chain(*self.behaviours.values()):
-            self.logger.info("Binding behaviour %s", behaviour)
-            behaviour.bind_output(self.output_event_queue)
-
         # Startup the inputs
         for _input in self.inputs:
             _input.bind(self.input_event_queue)
@@ -305,9 +299,19 @@ class BotRunner:
                 continue
 
             for event_type in self.behaviours:
-                if isinstance(event, event_type):
-                    for behaviour in self.behaviours[event_type]:
-                        await behaviour.process(event)
+                if not isinstance(event, event_type):
+                    continue
+
+                await asyncio.gather(
+                    self._process_event_for_behaviour(behaviour, event)
+                    for behaviour in self.behaviours[event_type]
+                )
+
+    async def _process_event_for_behaviour(
+        self, behaviour: BehaviourInterface, event: InputEvent
+    ) -> None:
+        async for output in behaviour.process(event):
+            await self.output_event_queue.put(output)
 
     async def process_output_queue(self) -> None:
         """

--- a/src/mewbot/core/__init__.py
+++ b/src/mewbot/core/__init__.py
@@ -254,7 +254,7 @@ class ActionInterface(Protocol):
         `state` will be available for any further actions that process this event.
         No functionality is provided to prevent processing more actions.
         """
-        yield OutputEvent()
+        yield OutputEvent()  # pragma: no cover (not reachable)
 
 
 @runtime_checkable
@@ -298,7 +298,7 @@ class BehaviourInterface(Protocol):
         If both of the above succeed, a state object is created, and the Event
         is passed to each action in turn, updating state and emitting any outputs.
         """
-        yield OutputEvent()
+        yield OutputEvent()  # pragma: no cover (not reachable)
 
 
 Component = Union[

--- a/src/mewbot/core/__init__.py
+++ b/src/mewbot/core/__init__.py
@@ -23,16 +23,13 @@ from __future__ import annotations
 
 from typing import (
     Any,
-    Dict,
-    List,
     Protocol,
-    Sequence,
-    Set,
-    Type,
-    Union,
     TypedDict,
+    Union,
     runtime_checkable,
 )
+
+from collections.abc import Iterable, AsyncIterable
 
 import asyncio
 import enum
@@ -90,7 +87,7 @@ class IOConfigInterface(Protocol):
     they are passed to the bot via the `get_inputs` and `get_outputs` methods.
     """
 
-    def get_inputs(self) -> Sequence[InputInterface]:
+    def get_inputs(self) -> Iterable[InputInterface]:
         """
         Gets the Inputs that are used to read events from the service.
 
@@ -100,7 +97,7 @@ class IOConfigInterface(Protocol):
         :return: The Inputs that are used to read events from the service (if any)
         """
 
-    def get_outputs(self) -> Sequence[OutputInterface]:
+    def get_outputs(self) -> Iterable[OutputInterface]:
         """
         Gets the Outputs that are used to send events to the service.
 
@@ -121,7 +118,7 @@ class InputInterface(Protocol):
     """
 
     @staticmethod
-    def produces_inputs() -> Set[Type[InputEvent]]:
+    def produces_inputs() -> set[type[InputEvent]]:
         """List the types of Events this Input class could produce."""
 
     def bind(self, queue: InputQueue) -> None:
@@ -152,7 +149,7 @@ class OutputInterface(Protocol):
     """
 
     @staticmethod
-    def consumes_outputs() -> Set[Type[OutputEvent]]:
+    def consumes_outputs() -> set[type[OutputEvent]]:
         """Defines the types of Event that this Output class can send."""
 
     async def output(self, event: OutputEvent) -> bool:
@@ -176,7 +173,7 @@ class TriggerInterface(Protocol):
     """
 
     @staticmethod
-    def consumes_inputs() -> Set[Type[InputEvent]]:
+    def consumes_inputs() -> set[type[InputEvent]]:
         """
         The subtypes of InputEvent that this component accepts.
 
@@ -204,7 +201,7 @@ class ConditionInterface(Protocol):
     """
 
     @staticmethod
-    def consumes_inputs() -> Set[Type[InputEvent]]:
+    def consumes_inputs() -> set[type[InputEvent]]:
         """
         The subtypes of InputEvent that this component accepts.
 
@@ -228,7 +225,7 @@ class ActionInterface(Protocol):
     """
 
     @staticmethod
-    def consumes_inputs() -> Set[Type[InputEvent]]:
+    def consumes_inputs() -> set[type[InputEvent]]:
         """
         The subtypes of InputEvent that this component accepts.
 
@@ -237,7 +234,7 @@ class ActionInterface(Protocol):
         """
 
     @staticmethod
-    def produces_outputs() -> Set[Type[OutputEvent]]:
+    def produces_outputs() -> set[type[OutputEvent]]:
         """
         The subtypes of OutputEvent that this component could generate.
 
@@ -246,15 +243,9 @@ class ActionInterface(Protocol):
         outputs to function as intended.
         """
 
-    def bind(self, queue: OutputQueue) -> None:
-        """
-        Attaches the output to the bot's output queue.
-
-        A queue processor will distribute output events put on this queue
-        to the outputs that are able to process them.
-        """
-
-    async def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
+    async def act(
+        self, event: InputEvent, state: dict[str, Any]
+    ) -> AsyncIterable[OutputEvent | None]:
         """
         Performs the action.
 
@@ -263,6 +254,7 @@ class ActionInterface(Protocol):
         `state` will be available for any further actions that process this event.
         No functionality is provided to prevent processing more actions.
         """
+        yield OutputEvent()
 
 
 @runtime_checkable
@@ -277,16 +269,14 @@ class BehaviourInterface(Protocol):
     order, which can read from or write to DataStores, and emit OutputEvents.
     """
 
-    def add(
-        self, component: Union[TriggerInterface, ConditionInterface, ActionInterface]
-    ) -> None:
+    def add(self, component: TriggerInterface | ConditionInterface | ActionInterface) -> None:
         """
         Adds a component to the behaviour which is one or more of a Tigger, Condition, or Action.
 
         Note that the order of Actions being added must be preserved.
         """
 
-    def consumes_inputs(self) -> Set[Type[InputEvent]]:
+    def consumes_inputs(self) -> set[type[InputEvent]]:
         """
         The set of InputEvents which are acceptable to one or more triggers.
 
@@ -298,14 +288,7 @@ class BehaviourInterface(Protocol):
         type without having to invoke the matching methods, which may be complex.
         """
 
-    def bind_output(self, output: OutputQueue) -> None:
-        """
-        Wrapper to bind the output queue to all actions in this behaviour.
-
-        See :meth:`mewbot.core.ActionInterface:bind_output`
-        """
-
-    async def process(self, event: InputEvent) -> None:
+    async def process(self, event: InputEvent) -> AsyncIterable[OutputEvent]:
         """
         Processes an InputEvent.
 
@@ -315,6 +298,7 @@ class BehaviourInterface(Protocol):
         If both of the above succeed, a state object is created, and the Event
         is passed to each action in turn, updating state and emitting any outputs.
         """
+        yield OutputEvent()
 
 
 Component = Union[
@@ -345,16 +329,16 @@ class ComponentKind(str, enum.Enum):
     DataSource = "DataSource"
 
     @classmethod
-    def values(cls) -> List[str]:
+    def values(cls) -> list[str]:
         """List of named values."""
 
         return list(e for e in cls)
 
     @classmethod
-    def interface(cls, value: ComponentKind) -> Type[Component]:
+    def interface(cls, value: ComponentKind) -> type[Component]:
         """Maps a value in this enum to the Interface for that component type."""
 
-        _map: Dict[ComponentKind, Type[Component]] = {
+        _map: dict[ComponentKind, type[Component]] = {
             cls.Behaviour: BehaviourInterface,
             cls.Trigger: TriggerInterface,
             cls.Condition: ConditionInterface,
@@ -374,15 +358,15 @@ class ConfigBlock(TypedDict):
     kind: str
     implementation: str
     uuid: str
-    properties: Dict[str, Any]
+    properties: dict[str, Any]
 
 
 class BehaviourConfigBlock(ConfigBlock):
     """YAML block for a behaviour, which includes the subcomponents."""
 
-    triggers: List[ConfigBlock]
-    conditions: List[ConfigBlock]
-    actions: List[ConfigBlock]
+    triggers: list[ConfigBlock]
+    conditions: list[ConfigBlock]
+    actions: list[ConfigBlock]
 
 
 __all__ = [

--- a/src/mewbot/demo.py
+++ b/src/mewbot/demo.py
@@ -10,7 +10,7 @@ This common elements are often used in various of the examples.
 
 from __future__ import annotations
 
-from typing import Set, Type, Dict, Any
+from typing import Set, Type, Dict, Any, AsyncIterable
 
 from mewbot.api.v1 import Condition, Trigger, Action, InputEvent, OutputEvent
 
@@ -77,7 +77,7 @@ class PrintAction(Action):
         """This action cannot produce any OutputEvents."""
         return set()
 
-    async def act(self, event: InputEvent, state: Dict[str, Any]) -> None:
+    async def act(self, event: InputEvent, state: Dict[str, Any]) -> AsyncIterable[None]:
         """
         Just print every event which comes through - which should be all of them.
 
@@ -87,3 +87,4 @@ class PrintAction(Action):
         :return:
         """
         print("Processed event", event)
+        yield None

--- a/src/mewbot/io/common.py
+++ b/src/mewbot/io/common.py
@@ -62,3 +62,176 @@ class PrintAction(Action):
         """
         print("Processed event", event)
         yield None
+
+
+class EventWithReplyMixIn(abc.ABC, InputEvent):
+    """
+    Mix-in/protocol to mark an event has having the ability to be replied to.
+
+    This is intended to aid the construction of multi-platform chatbots, by
+    having the same actions being able to respond to events from different
+    inputs in a platform-agnostic way.
+    """
+
+    @abc.abstractmethod
+    def get_sender_name(self) -> str:
+        """
+        Returns the human friend name/nickname of the user who sent the event.
+        """
+
+    @abc.abstractmethod
+    def get_sender_mention(self) -> str:
+        """
+        Returns the string contents required to mention/notify/ping the sender.
+
+        If the reply methods will automatically ping the user, this may just be
+        the human-readable username.
+        """
+
+    @abc.abstractmethod
+    def prepare_reply(self, message: str) -> OutputEvent:
+        """
+        Creates an OutputEvent which is a reply to this input event.
+
+        This event will be targeted at the same scope as the incoming message,
+        e.g. in the same channel. It is expected that all people who saw the
+        original message will also be able to see the reply.
+        """
+
+    @abc.abstractmethod
+    def prepare_reply_narrowest_scope(self, message: str) -> OutputEvent:
+        """
+        Creates an OutputEvent which is a reply to this input event.
+
+        This event will attempt to only be visible to a minimal number of
+        people which still includes the person who sent the message.
+        Note that for some systems, this may still be the original scope
+        of all users who could see the original message.
+
+        This function does not guarantee privacy, but is intended for use
+        where replies are not relevant to other users, and thus can clutter
+        up the main chat.
+        """
+
+
+class ReplyAction(Action):
+    """
+    Gives generic templated replies to any event with the Reply mix-in.
+
+    The message can either be a simple static string, or be a template based
+    on information from other actions. See the message setting for more details.
+    """
+
+    _message: Template
+    _narrow_reply: bool = False
+
+    @staticmethod
+    def consumes_inputs() -> set[type[InputEvent]]:
+        """
+        The reply action needs events that implement the reply protocol.
+        """
+
+        return {EventWithReplyMixIn}
+
+    @staticmethod
+    def produces_outputs() -> set[type[OutputEvent]]:
+        """
+        The reply action does not understand the event types, so we mark OutputEvent.
+        """
+
+        return {OutputEvent}
+
+    @property
+    def message(self) -> str:
+        """
+        The message format for replies to all events.
+
+        The message format can either be a static string, or have placeholders
+        that will be interpolated from information from the event or the previous
+        actions.
+
+        The two properties that are built in are `_username`, which will insert the
+        username (nickname) of the user who sent the message we're replying to,
+        and `_mention`, which will mention/ping/notify the user that we are replying.
+
+        Examples:
+            - Static message of "Hello, World!"
+            - Greet a user with "Hello, $_user!"
+            - Notify a user with "${_mention}, it's your turn to play!"
+
+        For combining with actions that set state, you will need to look at what
+        state information they set. For example, if we have an action that puts
+        the time of the next calendar event into a variables called
+        `next_event_name` and `next_event_time`, you might want to have a
+        reply that looks like:
+
+            "$_mention Coming up: $next_event_name starting at $next_event_time"
+        """
+
+        return self._message.template
+
+    @message.setter
+    def message(self, message: str) -> None:
+        template = Template(message)
+
+        if (
+            hasattr(template, "is_valid")
+            and not template.is_valid()  # pylint: disable=no-member
+        ):
+            raise ValueError("Message template is not valid")
+
+        self._message = template
+
+    @property
+    def narrow_reply(self) -> bool:
+        """
+        Whether to send replies to the same scope or attempt to use a narrower scope.
+
+        By default, replies are sent to the same scope as the message was received in.
+        This could be the same channel in a messaging app, or the same thread is a forum
+        like system.
+
+        If narrow_reply is enabled, we attempt to reply to a narrower scope; for example
+        the reply in a chat channel may be sent as a DM to the user. The only guarantees
+        that is given is that the user will be able to see the message.
+
+        A narrower reply does not mean that other people will not be able to see the message,
+        and this functionality is provided to reduce the "SPAM-ness" of replies
+        that are not relevant to other users. If you want to send actually private
+        messages, you will need to use actions related to the specific IO you
+        are using (e.g. Discord, Reddit, etc.)
+        """
+
+        return self._narrow_reply
+
+    @narrow_reply.setter
+    def narrow_reply(self, enabled: bool) -> None:
+        self._narrow_reply = enabled
+
+    async def act(
+        self, event: InputEvent, state: dict[str, Any]
+    ) -> AsyncIterable[OutputEvent]:
+        """
+        Reply to the received message.
+        """
+
+        if not isinstance(event, EventWithReplyMixIn):
+            return
+
+        message = self._message.safe_substitute(
+            {
+                "_user": event.get_sender_name(),
+                "_mention": event.get_sender_mention(),
+                **state,
+            }
+        )
+
+        if self._narrow_reply:
+            yield event.prepare_reply_narrowest_scope(message)
+        else:
+            yield event.prepare_reply(message)
+
+    def __str__(self) -> str:
+        """Explanation of this action."""
+
+        return f"Reply to the message with '{self._message.template}'"

--- a/src/mewbot/io/common.py
+++ b/src/mewbot/io/common.py
@@ -10,39 +10,13 @@ This common elements are often used in various of the examples.
 
 from __future__ import annotations
 
-from typing import Set, Type, Dict, Any, AsyncIterable
+import abc
 
-from mewbot.api.v1 import Condition, Trigger, Action, InputEvent, OutputEvent
+from collections.abc import AsyncIterable
+from string import Template
+from typing import Any
 
-
-class Foo(Condition):
-    """
-    Example, trivial, condition.
-    """
-
-    @staticmethod
-    def consumes_inputs() -> Set[Type[InputEvent]]:
-        """Foo consumes no Input Events."""
-        return set()
-
-    _channel: str
-
-    @property
-    def channel(self) -> str:
-        """String representation of the channel this Condition acts on."""
-        return self._channel
-
-    @channel.setter
-    def channel(self, val: str) -> None:
-        self._channel = val
-
-    def allows(self, event: InputEvent) -> bool:
-        """Foo always matches any InputEvent passed to it."""
-        return True
-
-    def __str__(self) -> str:
-        """Str rep of Foo - tells you what channel it's watching."""
-        return f"Foo(channel={self.channel})"
+from mewbot.api.v1 import Trigger, Action, InputEvent, OutputEvent
 
 
 class AllEventTrigger(Trigger):
@@ -53,7 +27,7 @@ class AllEventTrigger(Trigger):
     """
 
     @staticmethod
-    def consumes_inputs() -> Set[Type[InputEvent]]:
+    def consumes_inputs() -> set[type[InputEvent]]:
         """This trigger consumes all Input Events."""
         return {InputEvent}
 
@@ -68,16 +42,16 @@ class PrintAction(Action):
     """
 
     @staticmethod
-    def consumes_inputs() -> Set[Type[InputEvent]]:
+    def consumes_inputs() -> set[type[InputEvent]]:
         """This action triggers on all InputEvents."""
         return {InputEvent}
 
     @staticmethod
-    def produces_outputs() -> Set[Type[OutputEvent]]:
+    def produces_outputs() -> set[type[OutputEvent]]:
         """This action cannot produce any OutputEvents."""
         return set()
 
-    async def act(self, event: InputEvent, state: Dict[str, Any]) -> AsyncIterable[None]:
+    async def act(self, event: InputEvent, state: dict[str, Any]) -> AsyncIterable[None]:
         """
         Just print every event which comes through - which should be all of them.
 

--- a/tests/api/test_v1_behaviour.py
+++ b/tests/api/test_v1_behaviour.py
@@ -10,7 +10,7 @@ Test cases for the basic interface of the API v1 Behaviour class.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, AsyncIterable
 
 import pytest
 
@@ -148,8 +148,10 @@ class TestBehaviour:
             def produces_outputs() -> set[type[OutputEvent]]:
                 return {OutputEvent}
 
-            async def act(self, event: InputEvent, state: dict[str, Any]) -> None:
-                pass
+            async def act(
+                self, event: InputEvent, state: dict[str, Any]
+            ) -> AsyncIterable[OutputEvent]:
+                yield OutputEvent()
 
         behaviour = Behaviour("Test", True)
         action = TestAction()

--- a/tests/io/test_io_common.py
+++ b/tests/io/test_io_common.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Tests for the non-IO specific components.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+
+import pytest
+
+from mewbot.api.v1 import InputEvent
+from mewbot.core import OutputEvent
+from mewbot.io.common import AllEventTrigger, EventWithReplyMixIn, ReplyAction, PrintAction
+
+
+class TestCommonIO:
+    """
+    Tests for the non-IO specific components.
+    """
+
+    def test_all_event_trigger(self) -> None:
+        """
+        Tests for the trigger that matches all input events.
+        """
+
+        trigger = AllEventTrigger()
+
+        assert trigger.consumes_inputs() == {InputEvent}
+        assert trigger.matches(InputEvent())
+
+    async def test_print_output_action(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """
+        Tests for the trigger that matches all input events.
+        """
+
+        action = PrintAction()
+
+        assert action.consumes_inputs() == {InputEvent}
+        assert action.produces_outputs() == set()
+
+        actor = action.act(None, {})  # type: ignore
+        assert await actor.__anext__() is None  # type: ignore
+        with pytest.raises(StopAsyncIteration):
+            await actor.__anext__()  # type: ignore
+
+        captured_output = capsys.readouterr()
+        assert captured_output.err == ""
+        assert captured_output.out == "Processed event None\n"
+
+
+@dataclasses.dataclass
+class ReplyTestOutputEvent(OutputEvent):
+    """Fake OutputEvent for testing ReplyAction."""
+
+    message: str
+    narrow: bool
+
+
+class ReplyableTestEvent(EventWithReplyMixIn):
+    """Fake InputEvent for testing ReplyAction."""
+
+    def get_sender_name(self) -> str:
+        """Test sender name (sender)."""
+
+        return "sender"
+
+    def get_sender_mention(self) -> str:
+        """Test sender mention (sender)."""
+
+        return "@sender#0000"
+
+    def prepare_reply(self, message: str) -> OutputEvent:
+        """Create a Test output even with the given message."""
+
+        return ReplyTestOutputEvent(message, False)
+
+    def prepare_reply_narrowest_scope(self, message: str) -> OutputEvent:
+        """Create a Test output even with the given message."""
+
+        return ReplyTestOutputEvent(message, True)
+
+
+REPLY_MAP: list[tuple[str, bool, dict[str, str], str]] = [
+    ("Hello, World!", False, {}, "Hello, World!"),
+    ("Hello, World!", True, {}, "Hello, World!"),
+    ("Hello, ${_user}!", False, {}, "Hello, sender!"),
+]
+
+
+class TestReplyEvents:
+    """Tests for the ReplyAction."""
+
+    def test_reply_action_statics(self) -> None:
+        """Test statis methods on ReplyAction."""
+
+        assert ReplyAction.consumes_inputs() == {EventWithReplyMixIn}
+        assert ReplyAction.produces_outputs() == {OutputEvent}
+
+    def test_create_action(self) -> None:
+        """Creating the ReplyAction with not properties."""
+
+        action = ReplyAction()
+        assert not hasattr(action, "_message")
+        assert action.narrow_reply is False
+
+        with pytest.raises(AttributeError):
+            assert action.message
+
+    def test_create_action_with_message(self) -> None:
+        """Creating the ReplyAction with a message template."""
+
+        message = "Hello, World!"
+
+        action = ReplyAction(message=message)  # type: ignore
+
+        assert action.narrow_reply is False
+        assert action.message == message
+        assert str(action) == f"Reply to the message with '{message}'"
+
+    @pytest.mark.skipif(
+        sys.version_info <= (3, 11), reason="Check only supported on Python 3.11+"
+    )
+    def test_create_action_with_bad_template(self) -> None:
+        """Creating the ReplyAction with a message template."""
+        with pytest.raises(ValueError, match="Message template is not valid"):
+            ReplyAction(message="$")  # type: ignore
+
+    async def test_reply_bad_event(self) -> None:
+        """Creating the ReplyAction with a message template."""
+
+        action = ReplyAction()
+        iterable = action.act(InputEvent(), {})
+
+        with pytest.raises(StopAsyncIteration):
+            await iterable.__anext__()  # type: ignore
+
+    @pytest.mark.parametrize("message,narrow,state,reply", REPLY_MAP)
+    async def test_reply(
+        self, message: str, narrow: bool, state: dict[str, str], reply: str
+    ) -> None:
+        """Creating the ReplyAction with a message template."""
+
+        action = ReplyAction(message=message, narrow_reply=narrow)  # type: ignore
+        iterable = action.act(ReplyableTestEvent(), state)
+        event = await iterable.__anext__()  # type: ignore
+
+        assert isinstance(event, ReplyTestOutputEvent)
+        assert event.message == reply
+        assert event.narrow == narrow
+
+        with pytest.raises(StopAsyncIteration):
+            await iterable.__anext__()  # type: ignore


### PR DESCRIPTION
## Refactor Actions to not require knowledge of queues
    
This change makes each call to `Behaviour.process` and `Action.act`
less stateful by moving all references to the queue out to the bot
or runner levels of interaction.
Both of these methods now emit (in the form of an async generator)
all output events that would be created.

As many actions will not emit any events (for example for updating
state information of recording data to datastores), the ability to
`yield None` has been codified in. This allows dvelopers to ensure
they are providing an async generator.

## Refactor mewbot.demo into mewbot.io.common
    
The demo module was written very early in the project's development,
and includes code that doesn't do anything. The use pieces of code
have been moved to a new IO module, with tests added.

This resolves issue #166.

## Add 'Reply' generic events and action to the Common IO.
    
A InputEvent abstract class/mix-in/protocol has been added which
allows an InputEvent to create an OutputEvent which is a reply to it.

This event contains a string message, to which no formatting information
is assigned.

There are two scopes for the reply -- either the same scope as the
incoming message, or in a potentially 'narrower' scope which still
includes the sender, but fewer other people (such as a direct message).

These two modes may be equivalent.

A ReplyAction has also been added, using the `string.Template` to
format the current state into the message, making it able to combine
arbitrary IO systems with other arbitrary actions.
