### PR TITLE
Update `tools/path` to do python detection

### DIFF
--- a/tools/path
+++ b/tools/path
@@ -4,8 +4,53 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-PYTHON=${PYTHON:-python3}
+
+auto_detect_python()
+{
+  PYTHON=$(command -v python3 2>/dev/null)
+
+  if [ $? -eq 0 ]
+  then
+    printf >&2 "Selecting %s as python interpreter\n" "$PYTHON"
+    printf "%s" "$PYTHON"
+    return 0
+  fi
+
+  PYTHON=$(command -v python 2>/dev/null)
+
+  if [ $? -eq 0 ]
+  then
+    VERSION=$("$PYTHON" --version)
+
+    if [ $? -eq 0 ] && [ "$VERSION" != "${VERSION#Python }" ]
+    then
+      VERSION=${VERSION#Python }
+      MAJOR=${VERSION%%.*}
+
+      if [ "$MAJOR" -eq 3 ]
+      then
+        printf >&2 "Selecting %s as python interpreter\n" "$PYTHON"
+        printf "%s" "$PYTHON"
+        return 0
+      fi
+    fi
+  fi
+
+  printf >&2 "Unable to locate a python v3 interpreter as either 'python3' or 'python'\n"
+  printf >&2 "Make sure python is installed. If it is not on your PATH, you can specify a location with the PYTHON environment variable.\n"
+  return 1
+}
+
+if [ -z "$PYTHON" ]
+then
+  PYTHON=$(auto_detect_python)
+
+  test $? -eq 0 || exit 1
+fi
+
 readonly PYTHON
 
 PYTHONPATH="$("$PYTHON" src/mewbot/tools/path.py)"
+
+readonly PYTHONPATH
 export PYTHONPATH


### PR DESCRIPTION
`tools/path` will now select python interpreter with the following conditions:
 - Use whatever the user supplied in `$PYTHON`
 - Any binary on the path named 'python3'
 - Any binary on the path named 'python' that, when called as `python --version` returns `Python 3.[...]`

This should improve compatibility with systems where 'python' is usually a python3 installation, such as some Windows setups.