### PR TITLE
Mewbot discord dice roller example plugin

### DIFF
--- a/dev-docs/io-dev-notes/discord-dev-notes.md
+++ b/dev-docs/io-dev-notes/discord-dev-notes.md
@@ -4,6 +4,91 @@ SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
+# Running discord bot examples
+
+## acquire a discord token
+
+To run a bot on discord you need to acquire a bot token.
+This is a string of numbers and letters which identifies your bot to discord when it tries to log in.
+
+Tokens can have a number of different properties, or scopes.
+These determine what you can do with a token.
+
+I recommend following the [official discord guide](https://discordgsm.com/guide/how-to-get-a-discord-bot-token).
+Which should walk you through the process.
+
+Remember - if you want to view the contents of discord messages, you will need to enable the message content permission for the bot.
+If you don't do this, all the message contents you see will be blank.
+
+## prepare discord bot yaml
+
+Now select the bot you want to actually run.
+Each of the yaml files included in `examples\discord_bots` represents 
+
+```yaml
+kind: IOConfig
+implementation: mewbot.io.discord.DiscordIO
+uuid: aaaaaaaa-aaaa-4aaa-0000-aaaaaaaaaa00
+properties:
+  token: "[token goes here]"
+  
+---
+```
+
+Once you have prepared your token, paste it into the IOConfig block of the yaml for the bot you want to run.
+
+The IOConfig block, for your token, should look something like
+
+```yaml
+kind: IOConfig
+implementation: mewbot.io.discord.DiscordIO
+uuid: aaaaaaaa-aaaa-4aaa-0000-aaaaaaaaaa00
+properties:
+  token: "a-series-of-letters-and-numbers-that-is-your-token"
+  
+---
+```
+
+Note the ``" "`` around your token.
+This indicates, to the yaml, that your token should be treated as a string.
+If you omit them, the yaml will be invalid and will not run.
+
+### run the example - windows
+
+Turning mewbot yaml into a bot is a fairly straightforward operation.
+
+#### Through python and examples
+
+You can use the code in the `__main__.py` file of examples.
+Running something like 
+
+```shell
+(mewbot_venv) C:\mewbot_dev\mewbot>python src\examples examples\discord_bots\history_discord_bot.yaml
+```
+
+#### Through the examples file in tools
+
+You could also use the `sh` file found in the tools folder, running something like
+
+```shell
+(mewbot_venv) C:\mewbot_dev\mewbot>sh tools/examples examples\discord_bots\history_discord_bot.yaml
+```
+
+NOTE - the direction of the `/` in `tools/examples`.
+If you get it the wrong way round, `sh` would be able to interpret the path and you'll get an error like
+
+```shell
+(mewbot_venv) C:\mewbot_dev\mewbot>sh tools\examples examples\discord_bots\history_discord_bot.yaml
+tools\examples: line 7: tools\examples/path: Not a directory
+tools\examples: line 9: exec: : not found
+```
+
+### run the example - linux
+
+(I don't have a functioning linux box for this rn, so will fill this in later).
+
+## FAQ
+
 ### Why am I getting blank events when messages are sent in channels the bot is monitoring?
 
 As of late August 2022, discord bots now need the message content permission to be explicitly enabled (was implicitly enabled up to this point).

--- a/dev-docs/plugin-dev-notes/README.md
+++ b/dev-docs/plugin-dev-notes/README.md
@@ -16,7 +16,7 @@ It's designed to take yaml files, load them, and turn them into bots which can i
 While it does have some basic capabilities, the majority of its capabilities come from plugins
 (either plugins already bundled with the program or plugins written for it.)
 
-Thus, if you want to extend the capabilities of the _framework itself_ you probably want to write a **mewbot framework plugin**.
+If you want to extend the capabilities of the _framework itself_ you want to write a **mewbot framework plugin**.
 
 On a technical level this will take the form of a namespace plugin which will use the `mewbot_framework_plugin_template`.
 
@@ -25,9 +25,21 @@ I will write a plugin which will present a new IOConfig in `mewbot.io`
 
 For further information on how to write namespace plugins, please see the python core documentation - [python namespace plugin docs](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/).
 
+Your plugin will be used by installing your module and then calling the IOConfig using something like
+
+```yaml
+kind: IOConfig
+implementation: mewbot.io.mastadon.MastadonIO
+uuid: aaaaaaaa-aaaa-4aaa-0000-aaaaaaaaaa00
+properties:
+  token: "[your mastadon token goes here]"
+
+---
+```
+
 #### 2) Creating tools for bots
 
-If, on the other hand, you want to write some tools which bots _themselves_ will use, then you probably want to write a **mewbot bot plugin**.
+If, on the other hand, you want to write some tools which bots _themselves_ will use, then you may want to write a **mewbot bot plugin**.
 
 This would be a plugin for mewbot which does not add to the core module namespace.
 It might include detailed Triggers, Conditions and Actions that you will use to build your bot via yaml.
@@ -45,30 +57,30 @@ As a rule of thumb
 
 E.g.
 
-#### Example 1
+#### Example 1 - "I want to allow mewbot to talk to mastadon."
 
-"I want to allow mewbot to talk to mastadon"
-
-Probably write a **framework** plugin.
+Write a **framework** plugin.
 
 In fact, please do!
 That would really be very helpful.
 
 Your generic IOConfig will take the form of a namespace plugin.
-It will be used by importing it using something like
+It will be used by importing it from the wider mewbot namespace via something like this
 
 ```python
 from mewbot.io.mastadon import MastadonIOConfig
 ```
 
-#### Example 2
+It will, to all intents and purposes, serve as part of mewbot itself.
 
-"I've written a discord dice roller! I'd like to distribute it."
+#### Example 2 - "I've written a discord dice roller! I'd like to distribute it."
 
-Probably write a **bot** plugin.
+Write a **bot** plugin.
 
-Structure it how you like.
-Use the components by having lines such as 
+Structure it how you like - it matters a lot less for this sort of plugin than a namespace plugin.
+(Though there is an example in plugins under `mewbot-discord_dice_roller` which should serve to get you started).
+
+Use the components in your bot by having lines such as
 
 ```yaml
 kind: Behaviour
@@ -94,13 +106,27 @@ actions:
 
 ```
 
+in your yaml files.
+
 (descriptive names are preferred for this sort of plugin as the yaml is intended to be highly human readable).
 
-#### Example 3
+#### Example 3 - "I've written some awesome conditions. I want to distribute them."
 
-"I've written some awesome conditions. I want to distribute them."
-
-You probably want a **bot** plugin.
+You may want a **bot** plugin.
 But, if they are _extremely_ generic, they might be candidates for inclusion in `mewbot.io.common`.
 This will, however, be fairly rare.
 To keep the core framework as light weight as possible.
+
+#### Example 4 - "I want to help out by writing a plugin. What sort of plugin should I write?"
+
+As a rule of thumb
+ - **framework** plugins are harder to write, but more helpful
+ - **bot** plugins are easier to write, but less helpful
+
+Framework plugins allow mewbot bots to talk to more services.
+Which, for every service, vastly increases the number of useful bots than can be written.
+
+Bot components allow the bots to do more things.
+They provide capabilities, and allow each bot written for mewbot to do more.
+
+Both are very helpful!

--- a/dev-docs/plugin-dev-notes/README.md
+++ b/dev-docs/plugin-dev-notes/README.md
@@ -1,0 +1,106 @@
+
+# Plugin dev notes
+
+Notes on creating plugins and extensions for mewbot.
+
+## Plugin writing intro
+
+### Why you might want to write a plugin?
+
+There are two reasons - and two types of plugin you might want to write.
+
+#### 1) Extending mewbot itself
+
+Base mewbot is more a framework than a complete program.
+It's designed to take yaml files, load them, and turn them into bots which can interact with the world.
+While it does have some basic capabilities, the majority of its capabilities come from plugins
+(either plugins already bundled with the program or plugins written for it.)
+
+Thus, if you want to extend the capabilities of the _framework itself_ you probably want to write a **mewbot framework plugin**.
+
+On a technical level this will take the form of a namespace plugin which will use the `mewbot_framework_plugin_template`.
+
+E.g. I would like mewbot to be able to talk to "Insert communications protocol here".
+I will write a plugin which will present a new IOConfig in `mewbot.io`
+
+For further information on how to write namespace plugins, please see the python core documentation - [python namespace plugin docs](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/).
+
+#### 2) Creating tools for bots
+
+If, on the other hand, you want to write some tools which bots _themselves_ will use, then you probably want to write a **mewbot bot plugin**.
+
+This would be a plugin for mewbot which does not add to the core module namespace.
+It might include detailed Triggers, Conditions and Actions that you will use to build your bot via yaml.
+
+It might even include custom IOConfigs.
+Though, if you're going to the effort of writing one, please consider either
+1) extending an existing IOConfig with new capabilities
+2) writing a framework plugin to expose your IOConfig more broadly.
+
+### Which one should I use?
+
+As a rule of thumb
+1) If the plugin components should appear in the core namespace, write a **framework plugin**
+2) If the plugin components are to support a specific bot or a collection of bots, then write a **bot plugin**
+
+E.g.
+
+#### Example 1
+
+"I want to allow mewbot to talk to mastadon"
+
+Probably write a **framework** plugin.
+
+In fact, please do!
+That would really be very helpful.
+
+Your generic IOConfig will take the form of a namespace plugin.
+It will be used by importing it using something like
+
+```python
+from mewbot.io.mastadon import MastadonIOConfig
+```
+
+#### Example 2
+
+"I've written a discord dice roller! I'd like to distribute it."
+
+Probably write a **bot** plugin.
+
+Structure it how you like.
+Use the components by having lines such as 
+
+```yaml
+kind: Behaviour
+implementation: mewbot_discord_dice_roler.behaviors.DiceRollerBehavior
+uuid: aaaaaaaa-aaaa-4aaa-0000-aaaaaaaaaa02
+properties:
+  name: 'RSS Printer'
+triggers:
+  - kind: Trigger
+    implementation: mewbot.io.common.AllEventTrigger
+    uuid: aaaaaaaa-aaaa-4aaa-0000-aaaaaaaaaa03
+    properties: { }
+  - kind: Trigger
+    implementation: mewbot.io.common.AllEventTrigger
+    uuid: aaaaaaaa-aaaa-4aaa-0000-aaaaaaaaaa04
+    properties: { }
+conditions: []
+actions:
+  - kind: Action
+    implementation: mewbot_discord_dice_roller.actions.RollTheDice
+    uuid: aaaaaaaa-aaaa-4aaa-0000-aaaaaaaaaa05
+    properties: { }
+
+```
+
+(descriptive names are preferred for this sort of plugin as the yaml is intended to be highly human readable).
+
+#### Example 3
+
+"I've written some awesome conditions. I want to distribute them."
+
+You probably want a **bot** plugin.
+But, if they are _extremely_ generic, they might be candidates for inclusion in `mewbot.io.common`.
+This will, however, be fairly rare.
+To keep the core framework as light weight as possible.

--- a/dev-docs/plugin-dev-notes/running_examples.md
+++ b/dev-docs/plugin-dev-notes/running_examples.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# mewbot examples
+
+One of the best ways to learn how to use a system is to have an example of that system in action.
+
+E.g. There's a lot of variety in the IOConfigs written for mewbot.
+Each of them comments to a different service, with different rules, quirks, and, mostly, different access methods.
+As such, a working example is vital.
+As is some documentation as to how you get that example up and running.
+
+While this is true of framework plugins, it's also true of bot plugins.
+An example showing what you've built in action is often really helpful when it comes to helping others get it up and running.
+Or porting it to a different platform.
+
+# tokens
+
+Many of the services which mewbot connects to need tokens, or some equivalent, to run.
+
+You should include some basic instructions as to how to generate these tokens with your plugin - even if it's just a link to the instructions provided with the api.
+
+E.g. for how to run discord examples, please see `io-dev-notes/discord-dev-notes.md`

--- a/dev-docs/windows_dev_install/5 - Create venvs.md
+++ b/dev-docs/windows_dev_install/5 - Create venvs.md
@@ -175,7 +175,7 @@ This behavior is undocumented and may result in a non-functional system.
 Instead, create and add to a `.pth` file as described above, adding the line (in my case)
 
 ```shell
-C:\\mewbot_dev\\mewbot\plugins
+C:\mewbot_dev\mewbot\plugins
 ```
 
 to the file.

--- a/plugins/mewbot-discord_dice_roller/README.md
+++ b/plugins/mewbot-discord_dice_roller/README.md
@@ -1,0 +1,42 @@
+
+# mewbot-discord_dice_roller
+
+## Introduction
+
+This project serves a number of purposes.
+
+1) it is an example of how to write plugins for mewbot.
+
+(In particular, how to write a plugin to provide components for a mewbot bot - a `mewbot-bot` plugin.
+
+This is not intended to extend mewbot itself - it's a collection of utility methods.
+As such, it will not be included in the mewbot namespace.
+
+If you want that, you want to write a `mewbot-namespace` plugin).
+
+2) it's a fairly capable dice roller plugin which you can adapt - pretty quickly - to almost any text based input method.
+
+## Project contents
+
+This project provides examples of
+
+1) Defining a Trigger, Action and Behavior which can be detected and loaded by the registry.
+2) The basic `setup.py` file that you will need to include in your external projects to have them recognized as mewbot plugins.
+
+Conceptually, this is very simple.
+
+The registry - located in `mewbot.api.registry` stores all instances of the various mewbot components which inherit from the base classes in the api.
+All you need to register your class is to inherit from the `mewbot.api.v1` and include a special entry point in the `setup.py` file.
+
+This allows different bots to use their components - and for them to be made available through the GUI.
+
+## Ho do I use these components?
+
+There are two ways to do this
+
+1) Import the components directly from the `mewbot_discord_dice_roller` module
+2) Access them through the registry
+
+Which of these you use is up to you!
+
+Included in this module is two examples - one for each method.

--- a/plugins/mewbot-discord_dice_roller/examples/direct_import_dice_roller_bot.yaml
+++ b/plugins/mewbot-discord_dice_roller/examples/direct_import_dice_roller_bot.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
+kind: IOConfig
+implementation: mewbot.io.discord.DiscordIO
+uuid: aaaaaaaa-aaaa-4aaa-0001-aaaaaaaaaa00
+properties:
+  token: "[token goes here]"
+
+---
+
+kind: Behaviour
+implementation: mewbot_discord_dice_roller.behaviors.DiscordDiceRollerBehavior
+uuid: aaaaaaaa-aaaa-4aaa-0001-aaaaaaaaaa01
+properties:
+  name: 'Discord Dice Roller - Direct Import Version'
+triggers: []
+conditions: []
+actions: []

--- a/plugins/mewbot-discord_dice_roller/requirements.txt
+++ b/plugins/mewbot-discord_dice_roller/requirements.txt
@@ -1,0 +1,3 @@
+
+mewbot.api
+d20

--- a/plugins/mewbot-discord_dice_roller/setup.py
+++ b/plugins/mewbot-discord_dice_roller/setup.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Note - this is NOT intended to be used for local installation or as part of development.
+
+This is intended to make this module available via pypi
+It _should_ also work for local installation, but this functionality is not tested.
+"""
+
+raise NotImplementedError("Still under development.")
+
+# from pathlib import Path
+#
+# import setuptools  # type: ignore
+#
+# # Finding the right README.md and inheriting the mewbot licence
+# current_file = Path(__file__)
+# root_repo_dir = current_file.parents[2]
+# assert root_repo_dir.exists()
+#
+# with open(current_file.parent.joinpath("README.md"), "r", encoding="utf-8") as rmf:
+#     long_description = rmf.read()
+#
+# with open(root_repo_dir.joinpath("LICENSE.md"), "r", encoding="utf-8") as lf:
+#     true_licence = lf.read()
+#
+# with open(current_file.parent.joinpath("requirements.txt"), "r", encoding="utf-8") as rf:
+#     requirements = list(x for x in rf.read().splitlines(False) if x and not x.startswith("#"))
+#
+#
+#
+# # There are a number of bits of special sauce in this call
+# # - You can fill it out manually - for your project
+# # - You can copy this and make the appropriate changes
+# # - Or you can run "mewbot make_new_plugin" - and follow the onscreen instructions.
+# #   Which should take care of most of the fiddly bits for you.
+# setuptools.setup(
+#     name="mewbot-discord_dice_roller",  # Note the different "-" and "_" between this
+#     # and the entry_points/py_modules
+#     # However, here, note it's "mewbot-" - not "mewbot_"
+#     # If it's not "mewbot-" then the pattern the plugin manager uses to load plugins will fail
+#     version="0.0.1",
+#     author="Alex Cameron",
+#     install_requires=requirements,
+#     author_email="mewbot@quicksilver.london",
+#     description="Example discord dice roller for mewbot",
+#     long_description=long_description,
+#     long_description_content_type="text/markdown",
+#     url="https://github.com/mewler/mewbot",
+#     project_urls={
+#         "Bug Tracker": "https://github.com/mewler/mewbot/issues",
+#     },
+#     classifiers=[
+#         "Programming Language :: Python :: 3",
+#         f"License :: OSI Approved :: {true_licence}",
+#         "Framework :: mewbot",
+#         "Operating System :: OS Independent",
+#     ],
+#     package_dir={"": "src"},
+#     packages=setuptools.find_packages(where="src"),
+#     # see https://packaging.python.org/en/latest/specifications/entry-points/
+#     # Note -
+#     entry_points={"mewbot-v1": ["discord_dice_roller = mewbot_discord_dice_roller"]},
+#     # Note this setup
+#     # The key for the entry point should always be "mewbot"
+#     # The value should be a string of the form "{prefix less name} = {py_modules name}"
+#     # The "py_modules name" should match one of the py_modules declared below
+#     python_requires=">=3.9",  # Might be relaxed later
+#     py_modules=["mewbot_discord_dice_roller"],
+# )
+#

--- a/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/__init__.py
+++ b/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/__init__.py
@@ -1,0 +1,3 @@
+"""
+Provides Components to allow you to create a discord dice roller.
+"""

--- a/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/__init__.py
+++ b/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/__init__.py
@@ -1,3 +1,6 @@
 """
 Provides Components to allow you to create a discord dice roller.
+
+For how to run the examples bundled with this, please see
+`io-dev-notes/discord-dev-notes.md`.
 """

--- a/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/actions.py
+++ b/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/actions.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# pylint: disable=duplicate-code
+# this is an example - duplication for emphasis is desirable
+
+"""
+The actions for this discord dice roller bot call d20 to actually produce the output.
+
+It parses the incoming string, uses it in d20, and produces a result.
+"""
+
+
+from __future__ import annotations
+
+from typing import Any, Dict, Set, Type, AsyncIterable
+
+import logging
+
+import d20  # type: ignore
+
+from mewbot.api.v1 import Action
+from mewbot.core import InputEvent, OutputEvent, OutputQueue
+from mewbot.io.discord import DiscordMessageCreationEvent, DiscordOutputEvent
+
+
+class DiscordRollTextResponse(Action):
+    """
+    Parse the payload, roll the dice and return.
+    """
+
+    _logger: logging.Logger
+    _queue: OutputQueue
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._logger = logging.getLogger(__name__ + type(self).__name__)
+
+    @staticmethod
+    def consumes_inputs() -> Set[Type[InputEvent]]:
+        """
+        This action only responds to DiscordMessageCreationEvents.
+
+        :return:
+        """
+        return {DiscordMessageCreationEvent}
+
+    @staticmethod
+    def produces_outputs() -> Set[Type[OutputEvent]]:
+        """
+        Produces DiscordOutputEvents - which should be replies to the original message.
+
+        :return:
+        """
+        return {DiscordOutputEvent}
+
+    async def act(
+        self, event: InputEvent, state: Dict[str, Any]
+    ) -> AsyncIterable[OutputEvent | None]:
+        """
+        Construct a DiscordOutputEvent with the result of rolling the dice.
+        """
+        if not isinstance(event, DiscordMessageCreationEvent):
+            self._logger.warning("Received wrong event type %s", type(event))
+            return
+
+        msg_text = str(event.message.content)
+
+        # A way to directly get at the code of this while running would be good
+        if not msg_text.startswith("!roll"):
+            self._logger.warning("Received a message with bad content %s", msg_text)
+            return
+
+        msg_payload = msg_text[5:].strip()
+
+        self._logger.info('Calling d20.roll with payload "%s"', msg_payload)
+        try:
+            payload_result = d20.roll(msg_payload)
+        except d20.errors.RollSyntaxError as exp:
+            self._logger.warning(
+                "d20 got an input it could not parse - %s - %s", msg_payload, exp
+            )
+            return
+
+        test_event = DiscordOutputEvent(
+            text=payload_result, message=event.message, use_message_channel=True
+        )
+
+        yield test_event

--- a/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/behaviors.py
+++ b/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/behaviors.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+"""
+This Behavior brings all the componets for the Discord Dice roller together in one place.
+"""
+
+
+from typing import Any
+
+from mewbot.api.v1 import Behaviour
+
+from .triggers import DiscordDiceRollCommandTrigger
+from .actions import DiscordRollTextResponse
+
+
+class DiscordDiceRollerBehavior(Behaviour):
+    """
+    Dice rolling behavior which automatically includes the needed triggers and actions.
+
+    These are
+     - DiscordRollCommandTrigger
+     - DiscordRollTextResponse
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """
+        Passthrough to the super - which does the actual init work.
+
+        Then adds the dice roller trigger and action.
+        :param args:
+        :param kwargs:
+        """
+        super().__init__(*args, **kwargs)
+
+        # Adding the trigger and action to the Behavior
+        self.add(DiscordDiceRollCommandTrigger())
+        self.add(DiscordRollTextResponse())
+
+    def __str__(self) -> str:
+        """
+        String representation of the behavior.
+
+        :return:
+        """
+        return (
+            f"DiscordDiceRollerBehavior - "
+            f"with actions {self.actions} - "
+            f"with triggers {self.triggers}"
+        )

--- a/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/behaviors.py
+++ b/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/behaviors.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-This Behavior brings all the componets for the Discord Dice roller together in one place.
+This Behavior brings all the components for the Discord Dice roller together in one place.
 """
 
 

--- a/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/triggers.py
+++ b/plugins/mewbot-discord_dice_roller/src/mewbot_discord_dice_roller/triggers.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# pylint: disable=duplicate-code
+# this is an example - duplication for emphasis is desirable
+
+"""
+Triggers every time a discord message is created.
+"""
+
+from __future__ import annotations
+
+from typing import Set, Type
+
+from mewbot.api.v1 import Trigger
+from mewbot.core import InputEvent
+from mewbot.io.discord import DiscordMessageCreationEvent
+
+
+class DiscordDiceRollCommandTrigger(Trigger):
+    """
+    Fires every time a DiscordMessageCreationEvent has text that starts with "!roll".
+    """
+
+    @staticmethod
+    def consumes_inputs() -> Set[Type[InputEvent]]:
+        """
+        Triggers off all DiscordMessageCreationEvents.
+
+        :return:
+        """
+        return {DiscordMessageCreationEvent}
+
+    def matches(self, event: InputEvent) -> bool:
+        """
+        Matches all DiscordMessageCreationEvent with the starting keyword !roll.
+
+        :param event:
+        :return:
+        """
+
+        if not isinstance(event, DiscordMessageCreationEvent):
+            return False
+
+        print(f"In matches with {event=}")
+
+        return event.text.startswith("!roll")

--- a/src/examples/__main__.py
+++ b/src/examples/__main__.py
@@ -13,11 +13,16 @@ from __future__ import annotations
 import sys
 
 import mewbot.loader
+from mewbot.tools.path import gather_paths
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage", sys.argv[0], " [configuration name]")
         sys.exit(1)
+
+    # Extend paths so the included plugin examples can be run
+    # (this is done for you in tools/examples in the top level of the repo)
+    sys.path.extend(gather_paths("src"))
 
     with open(sys.argv[1], "r", encoding="utf-8") as config:
         bot = mewbot.loader.configure_bot("DemoBot", config)

--- a/src/mewbot/api/registry.py
+++ b/src/mewbot/api/registry.py
@@ -29,6 +29,8 @@ import importlib_metadata
 from mewbot.core import ComponentKind, Component
 
 
+# This is the magic string needed when defining the entry points to have components
+# declared in a plugin automatically registered at registry startup
 API_DISTRIBUTIONS = ["mewbot-v1"]
 
 

--- a/src/mewbot/api/v1.py
+++ b/src/mewbot/api/v1.py
@@ -420,7 +420,6 @@ class Behaviour(Component):
         If both of the above succeed, a state object is created, and the Event
         is passed to each action in turn, updating state and emitting any outputs.
         """
-
         if not any(True for trigger in self.triggers if trigger.matches(event)):
             return
 

--- a/src/mewbot/bot.py
+++ b/src/mewbot/bot.py
@@ -302,10 +302,12 @@ class BotRunner:
                 if not isinstance(event, event_type):
                     continue
 
-                await asyncio.gather(
+                async_tasks = [
                     self._process_event_for_behaviour(behaviour, event)
                     for behaviour in self.behaviours[event_type]
-                )
+                ]
+
+                await asyncio.gather(*async_tasks)
 
     async def _process_event_for_behaviour(
         self, behaviour: BehaviourInterface, event: InputEvent

--- a/tools/examples
+++ b/tools/examples
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2021 - 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+. "${0%/*}/path"
+
+exec "$PYTHON" -m examples "$@"


### PR DESCRIPTION
 - aims to resolve https://github.com/mewbotorg/mewbot/issues/182
 - minor correction to the windows dev install docs
 - added example of direct import - access through registry needs more work than should be accommodated in this pull request
 - added mewbot-discord_dice_roller plugin with example
 - upgraded examples to allow running of examples stored in builtin plugins via path manipulation
 - added an "examples" sh script - through which you can run the examples
 - added notes to API_DISTRIBUTIONS constant in registry
 - fixed weird issue in bot which was preventing run - on windows - with some python versions

Still todo
 - sort out packaging for modules
 - write an interface for registry to allow direct listing and loading of modules from there
however, including these would grow this pull request beyond reasonable scope