### PR TITLE
Improve handling in tools/path

### DIFF
--- a/tools/path
+++ b/tools/path
@@ -4,48 +4,51 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-
 auto_detect_python()
 {
-  PYTHON=$(command -v python3 2>/dev/null)
-
-  if [ $? -eq 0 ]
+  # Detect a binary called 'python3'
+  # We automatically assume this has a valid version.
+  if PYTHON=$(command -v python3 2>/dev/null)
   then
-    printf >&2 "Selecting %s as python interpreter\n" "$PYTHON"
     printf "%s" "$PYTHON"
     return 0
   fi
 
-  PYTHON=$(command -v python 2>/dev/null)
-
-  if [ $? -eq 0 ]
+  # Detect a binary called 'python'
+  if ! PYTHON=$(command -v python 2>/dev/null)
   then
-    VERSION=$("$PYTHON" --version)
-
-    if [ $? -eq 0 ] && [ "$VERSION" != "${VERSION#Python }" ]
-    then
-      VERSION=${VERSION#Python }
-      MAJOR=${VERSION%%.*}
-
-      if [ "$MAJOR" -eq 3 ]
-      then
-        printf >&2 "Selecting %s as python interpreter\n" "$PYTHON"
-        printf "%s" "$PYTHON"
-        return 0
-      fi
-    fi
+    return 1
   fi
 
-  printf >&2 "Unable to locate a python v3 interpreter as either 'python3' or 'python'\n"
-  printf >&2 "Make sure python is installed. If it is not on your PATH, you can specify a location with the PYTHON environment variable.\n"
-  return 1
+  # Confirm it is actually a python binary
+  if ! VERSION=$("$PYTHON" --version) || ! [ "$VERSION" != "${VERSION#Python }" ]
+  then
+    return 1
+  fi
+
+  # Extract the major version number
+  VERSION=${VERSION#Python }
+  MAJOR=${VERSION%%.*}
+
+  if [ "$MAJOR" -ne 3 ]
+  then
+    return 1
+  fi
+
+  printf "%s" "$PYTHON"
 }
 
+# Detect python binary if not set in the environment.
 if [ -z "$PYTHON" ]
 then
-  PYTHON=$(auto_detect_python)
+  if ! PYTHON=$(auto_detect_python)
+  then
+    printf >&2 "Unable to locate a python v3 interpreter as either 'python3' or 'python'\n"
+    printf >&2 "Make sure python is installed. If it is not on your PATH, you can specify a location with the PYTHON environment variable.\n"
+    exit 1
+  fi
 
-  test $? -eq 0 || exit 1
+  printf >&2 "Selecting %s as python interpreter\n" "$PYTHON"
 fi
 
 readonly PYTHON


### PR DESCRIPTION
The logic to detect the python binary path has been enhanced by seperating user-communication from the execution flow, and making use of shell if-statement features that were recommended by shell-check.

This change was inspired during a rebase of #169 