### PR TITLE
Adding the type guard decorator

### DIFF
--- a/tests/api/type_guard/test_type_guard_checks_no_future_annotations.py
+++ b/tests/api/type_guard/test_type_guard_checks_no_future_annotations.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Tests pre_filter_non_matching_events using a dummy Trigger.
+"""
+
+# pylint: disable=duplicate-code
+# this is testing for identical behavior in two very similar cases
+# duplication is inevitable
+
+from typing import Union
+
+import pytest
+
+from mewbot.api.v1 import InputEvent, Trigger, pre_filter_non_matching_events
+from mewbot.io.http import IncomingWebhookEvent
+from mewbot.io.socket import SocketInputEvent
+
+TYPE_ERROR_MESSAGE = r".*.matches: Can not add filter for non-event type\(s\): .*"
+
+
+class SimpleTestTrigger(Trigger):
+    """Testing Trigger - Single Event sub-type."""
+
+    @staticmethod
+    def consumes_inputs() -> set[type[InputEvent]]:
+        """
+        Consume a specific type of Events.
+
+        :return:
+        """
+        return {SocketInputEvent}
+
+    @pre_filter_non_matching_events
+    def matches(self, event: SocketInputEvent) -> bool:
+        """
+        If the event is of the right type, matches.
+
+        :param event:
+        :return:
+        """
+        return True
+
+
+class UnionTestTrigger(Trigger):
+    """
+    Dummy trigger for testing.
+    """
+
+    @staticmethod
+    def consumes_inputs() -> set[type[InputEvent]]:
+        """
+        Consumes two radically different events.
+
+        :return:
+        """
+        return {SocketInputEvent, IncomingWebhookEvent}
+
+    @pre_filter_non_matching_events
+    def matches(self, event: Union[SocketInputEvent, IncomingWebhookEvent]) -> bool:
+        """
+        If the event is of the right type, matches.
+
+        :param event:
+        :return:
+        """
+        return True
+
+
+class PEP604TestTrigger(Trigger):
+    """
+    Dummy trigger for testing.
+    """
+
+    @staticmethod
+    def consumes_inputs() -> set[type[InputEvent]]:
+        """
+        Consumes two radically different events.
+
+        :return:
+        """
+        return {SocketInputEvent, IncomingWebhookEvent}
+
+    @pre_filter_non_matching_events
+    def matches(self, event: SocketInputEvent | IncomingWebhookEvent) -> bool:
+        """
+        If the event is of the right type, matches.
+
+        :param event:
+        :return:
+        """
+        return True
+
+
+class TestCheckInputEventAgainstSigTypesAnnotations:
+    """
+    Check the type guard annotation pre_filter_non_matching_events preforms as expected.
+    """
+
+    @pytest.mark.parametrize(
+        "clazz", [SimpleTestTrigger, UnionTestTrigger, PEP604TestTrigger]
+    )
+    def test_match_on_base_input_event_fails_annotations(self, clazz: type[Trigger]) -> None:
+        """
+        Calls the decorated function with the base class for InputEvent.
+
+        Should always fail.
+        :return:
+        """
+        assert clazz().matches(InputEvent()) is False
+
+    @pytest.mark.parametrize(
+        "clazz", [SimpleTestTrigger, UnionTestTrigger, PEP604TestTrigger]
+    )
+    def test_match_two_of_two_valid_event_types_annotations(
+        self, clazz: type[Trigger]
+    ) -> None:
+        """
+        Tests that a valid event type does match - for IncomingWebhookEvent.
+
+        :return:
+        """
+        test_socket_event = SocketInputEvent(data=b"some bytes")
+
+        assert clazz().matches(test_socket_event) is True
+
+    @pytest.mark.parametrize("clazz", [UnionTestTrigger, PEP604TestTrigger])
+    def test_match_one_of_two_valid_event_types_annotations(
+        self, clazz: type[Trigger]
+    ) -> None:
+        """
+        Tests that a valid event type does match - for IncomingWebhookEvent.
+
+        :return:
+        """
+        test_webhook_event = IncomingWebhookEvent(text="test_text")
+
+        assert clazz().matches(test_webhook_event) is True
+
+    @pytest.mark.parametrize(
+        "clazz", [SimpleTestTrigger, UnionTestTrigger, PEP604TestTrigger]
+    )
+    def test_complete_the_wrong_class_in_as_an_event_annotations(
+        self, clazz: type[Trigger]
+    ) -> None:
+        """
+        Tests that the decorator raises a type error when we pass something complete wrong in.
+
+        In place of an event
+        :return:
+        """
+        try:
+            clazz().matches(None)  # type: ignore
+        except TypeError:
+            pass

--- a/tests/api/type_guard/test_type_guard_checks_with_future_annotations.py
+++ b/tests/api/type_guard/test_type_guard_checks_with_future_annotations.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2023 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Tests pre_filter_non_matching_events using a dummy Trigger.
+"""
+
+# pylint: disable=duplicate-code
+# this is testing for identical behavior in two very similar cases
+# duplication is inevitable
+
+from __future__ import annotations
+
+from typing import Union
+
+import pytest
+
+from mewbot.api.v1 import InputEvent, Trigger, pre_filter_non_matching_events
+from mewbot.io.http import IncomingWebhookEvent
+from mewbot.io.socket import SocketInputEvent
+
+
+class SimpleTestTrigger(Trigger):
+    """Testing Trigger - Single Event sub-type."""
+
+    @staticmethod
+    def consumes_inputs() -> set[type[InputEvent]]:
+        """
+        Consume a specific type of Events.
+
+        :return:
+        """
+        return {SocketInputEvent}
+
+    @pre_filter_non_matching_events
+    def matches(self, event: SocketInputEvent) -> bool:
+        """
+        If the event is of the right type, matches.
+
+        :param event:
+        :return:
+        """
+        return True
+
+
+class UnionTestTrigger(Trigger):
+    """
+    Dummy trigger for testing.
+    """
+
+    @staticmethod
+    def consumes_inputs() -> set[type[InputEvent]]:
+        """
+        Consumes two radically different events.
+
+        :return:
+        """
+        return {SocketInputEvent, IncomingWebhookEvent}
+
+    @pre_filter_non_matching_events
+    def matches(self, event: Union[SocketInputEvent, IncomingWebhookEvent]) -> bool:
+        """
+        If the event is of the right type, matches.
+
+        :param event:
+        :return:
+        """
+        return True
+
+
+class PEP604TestTrigger(Trigger):
+    """
+    Dummy trigger for testing.
+    """
+
+    @staticmethod
+    def consumes_inputs() -> set[type[InputEvent]]:
+        """
+        Consumes two radically different events.
+
+        :return:
+        """
+        return {SocketInputEvent, IncomingWebhookEvent}
+
+    @pre_filter_non_matching_events
+    def matches(self, event: SocketInputEvent | IncomingWebhookEvent) -> bool:
+        """
+        If the event is of the right type, matches.
+
+        :param event:
+        :return:
+        """
+        return True
+
+
+class TestCheckInputEventAgainstSigTypesAnnotations:
+    """
+    Check the type guard annotation pre_filter_non_matching_events preforms as expected.
+    """
+
+    @pytest.mark.parametrize(
+        "clazz", [SimpleTestTrigger, UnionTestTrigger, PEP604TestTrigger]
+    )
+    def test_match_on_base_input_event_fails_annotations(self, clazz: type[Trigger]) -> None:
+        """
+        Calls the decorated function with the base class for InputEvent.
+
+        Should always fail.
+        :return:
+        """
+        assert clazz().matches(InputEvent()) is False
+
+    @pytest.mark.parametrize(
+        "clazz", [SimpleTestTrigger, UnionTestTrigger, PEP604TestTrigger]
+    )
+    def test_match_two_of_two_valid_event_types_annotations(
+        self, clazz: type[Trigger]
+    ) -> None:
+        """
+        Tests that a valid event type does match - for IncomingWebhookEvent.
+
+        :return:
+        """
+        test_socket_event = SocketInputEvent(data=b"some bytes")
+
+        assert clazz().matches(test_socket_event) is True
+
+    @pytest.mark.parametrize("clazz", [UnionTestTrigger, PEP604TestTrigger])
+    def test_match_one_of_two_valid_event_types_annotations(
+        self, clazz: type[Trigger]
+    ) -> None:
+        """
+        Tests that a valid event type does match - for IncomingWebhookEvent.
+
+        :return:
+        """
+        test_webhook_event = IncomingWebhookEvent(text="test_text")
+
+        assert clazz().matches(test_webhook_event) is True
+
+    @pytest.mark.parametrize(
+        "clazz", [SimpleTestTrigger, UnionTestTrigger, PEP604TestTrigger]
+    )
+    def test_complete_the_wrong_class_in_as_an_event_annotations(
+        self, clazz: type[Trigger]
+    ) -> None:
+        """
+        Tests that the decorator raises a type error when we pass something complete wrong in.
+
+        In place of an event
+        :return:
+        """
+        try:
+            clazz().matches(None)  # type: ignore
+        except TypeError:
+            pass

--- a/tests/api/type_guard/test_type_guard_invalid_config.py
+++ b/tests/api/type_guard/test_type_guard_invalid_config.py
@@ -1,0 +1,164 @@
+"""
+Test attempting to use the type guard for Triggers and Conditions in various invalid configurations.
+"""
+
+from __future__ import annotations
+
+import types
+import typing
+from typing import Optional, Union
+
+import pytest
+
+from mewbot.api.v1 import pre_filter_non_matching_events
+from mewbot.core import InputEvent
+from mewbot.io.http import IncomingWebhookEvent
+from mewbot.io.socket import SocketInputEvent
+
+union_type: Optional[type] = getattr(types, "UnionType", None)
+
+TYPE_ERROR_MESSAGE = r".*.matches: Can not add filter for non-event type\(s\): .*"
+
+
+class TestCheckInputEventAgainstSigTypesAnnotations:
+    """
+    Check the type guard annotation check_input_event_against_sig_types preforms as expected.
+    """
+
+    def test_union_syntax_on_different_versions(self) -> None:
+        """
+        Probe annoyance where the union syntax seems to yield different results on 3.9 and 3.10.
+
+        Preserved here as a canary for when a future version of python changes this behavior.
+        Which will hopefully be soon.
+        Either I'm missing something, or it's stupid.
+        :return:
+        """
+        assert union_type is not None, "union_type was None - change to python syntax?"
+
+        # This is not valid syntax in python 3.9 - so need to ignore it for mypy
+        test_syntax_1 = SocketInputEvent | IncomingWebhookEvent
+        # pylint: disable=isinstance-second-argument-not-valid-type
+        assert isinstance(test_syntax_1, union_type)
+        # pylint: disable=protected-access
+        assert not isinstance(test_syntax_1, typing._UnionGenericAlias)  # type: ignore
+
+        test_syntax_2 = Union[SocketInputEvent, IncomingWebhookEvent]
+        # You would really hope this would work ... but, alas, it does not
+        # pylint: disable=isinstance-second-argument-not-valid-type
+        assert not isinstance(test_syntax_2, union_type)
+        # pylint: disable=protected-access
+        assert isinstance(test_syntax_2, typing._UnionGenericAlias)  # type: ignore
+
+    def test_malformed_trigger_no_event_annotations(self) -> None:
+        """
+        Tests applying the decorator to a function without "event" as a possibility.
+
+        :return:
+        """
+        with pytest.raises(TypeError, match="Received function without 'event' parameter"):
+
+            @pre_filter_non_matching_events  # type: ignore
+            def consumes_inputs() -> set[type[InputEvent]]:
+                """
+                Consumes two radically different events.
+
+                :return:
+                """
+                return {SocketInputEvent, IncomingWebhookEvent}
+
+    def test_malformed_trigger_bad_event_type_none_annotations(self) -> None:
+        """
+        Tests applying the decorator to a function without "event" as a possibility.
+
+        :return:
+        """
+
+        with pytest.raises(TypeError, match=TYPE_ERROR_MESSAGE):
+
+            @pre_filter_non_matching_events  # type: ignore
+            def matches(event: None) -> bool:
+                """
+                If the event is of the right type, matches.
+
+                :param event:
+                :return:
+                """
+                return not event
+
+    def test_malformed_trigger_bad_event_type_trigger_annotations(self) -> None:
+        """
+        Tests applying the decorator to a function without "event" as a possibility.
+
+        :return:
+        """
+        with pytest.raises(
+            TypeError,
+            match=(
+                r'(can only concatenate str \(not "int"\) to str|'
+                r"Forward references must evaluate to types. Got 7.)"
+            ),
+        ):
+
+            @pre_filter_non_matching_events  # type: ignore
+            def matches(event: 7) -> bool:  # type: ignore
+                """
+                If the event is of the right type, matches.
+
+                :param event:
+                :return:
+                """
+                return not event
+
+    def test_malformed_trigger_no_event_annotations2(self) -> None:
+        """
+        Tests applying the decorator to a function without "event" as a possibility.
+
+        :return:
+        """
+        with pytest.raises(TypeError, match="Received function without 'event' parameter"):
+
+            @pre_filter_non_matching_events  # type: ignore
+            def consumes_inputs() -> set[type[InputEvent]]:
+                """
+                Consumes two radically different events.
+
+                :return:
+                """
+                return {SocketInputEvent, IncomingWebhookEvent}
+
+    def test_malformed_trigger_bad_event_type_none_annotations2(self) -> None:
+        """
+        Tests applying the decorator to a function without "event" as a possibility.
+
+        :return:
+        """
+        with pytest.raises(TypeError, match=TYPE_ERROR_MESSAGE):
+
+            @pre_filter_non_matching_events  # type: ignore
+            def matches(event: None) -> bool:
+                """
+                If the event is of the right type, matches.
+
+                :param event:
+                :return:
+                """
+                return bool(event)
+
+    def test_malformed_trigger_bad_event_type_trigger_annotations2(self) -> None:
+        """
+        Tests applying the decorator to a function without "event" as a possibility.
+
+        :return:
+        """
+        with pytest.raises(TypeError, match=TYPE_ERROR_MESSAGE):
+
+            @pre_filter_non_matching_events  # type: ignore
+            def matches(event: object) -> bool:
+                """
+                If the event is of the right type, matches.
+
+                :param event:
+                :return:
+                """
+                return bool(event)


### PR DESCRIPTION
 - in api - seemed the most appropriate place for it
 - (if nothing else, because it needed less cross module imports)
 - added extensive docs including example code
 - selected the option which didn't confuse pycharm - as that seems to be harder to fix
 - included a test suite hitting 100% of the module
 - decorator not currently applied to the examples - would seem beyond the scope of a single pull request
 - Not over sold on the name - but felt descriptive was better