### PR TITLE
Enhanced plugin packaging - adding setup.py e.t.c. to plugins - adding discord-dice-roller example

### DIFF
--- a/dev-docs/plugin-dev-notes/README.md
+++ b/dev-docs/plugin-dev-notes/README.md
@@ -21,7 +21,7 @@ It's designed to take yaml files, load them, and turn them into bots which can i
 While it does have some basic capabilities, the majority of its capabilities come from plugins
 (either plugins already bundled with the program or plugins written for it.)
 
-If you want to extend the capabilities of the _framework itself_ you want to write a **mewbot framework plugin**.
+Thus, if you want to extend the capabilities of the _framework itself_ you probably want to write a **mewbot framework plugin**.
 
 On a technical level this will take the form of a namespace plugin which will use the `mewbot_framework_plugin_template`.
 
@@ -29,6 +29,10 @@ E.g. I would like mewbot to be able to talk to "Insert communications protocol h
 I will write a plugin which will present a new IOConfig in `mewbot.io`
 
 For further information on how to write namespace plugins, please see the python core documentation - [python namespace plugin docs](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/).
+
+#### 2) Creating tools for bots
+
+If, on the other hand, you want to write some tools which bots _themselves_ will use, then you probably want to write a **mewbot bot plugin**.
 
 Your plugin will be used by installing your module and then calling the IOConfig using something like
 
@@ -41,10 +45,6 @@ properties:
 
 ---
 ```
-
-#### 2) Creating tools for bots
-
-If, on the other hand, you want to write some tools which bots _themselves_ will use, then you may want to write a **mewbot bot plugin**.
 
 This would be a plugin for mewbot which does not add to the core module namespace.
 It might include detailed Triggers, Conditions and Actions that you will use to build your bot via yaml.
@@ -70,6 +70,7 @@ In fact, please do!
 That would really be very helpful.
 
 Your generic IOConfig will take the form of a namespace plugin.
+
 It will be used by importing it from the wider mewbot namespace via something like this
 
 ```python
@@ -86,6 +87,7 @@ Structure it how you like - it matters a lot less for this sort of plugin than a
 (Though there is an example in plugins under `mewbot-discord_dice_roller` which should serve to get you started).
 
 Use the components in your bot by having lines such as
+
 
 ```yaml
 kind: Behaviour
@@ -110,7 +112,6 @@ actions:
     properties: { }
 
 ```
-
 in your yaml files.
 
 (descriptive names are preferred for this sort of plugin as the yaml is intended to be highly human readable).
@@ -134,4 +135,6 @@ Which, for every service, vastly increases the number of useful bots than can be
 Bot components allow the bots to do more things.
 They provide capabilities, and allow each bot written for mewbot to do more.
 
-Both are very helpful!
+Both are very useful!
+
+If you have any issues or doubts, feel free to contact us and we'll try to help!

--- a/plugins/mewbot-discord_dice_roller/LICENSE.md
+++ b/plugins/mewbot-discord_dice_roller/LICENSE.md
@@ -1,0 +1,1 @@
+../../LICENSES/BSD-2-Clause.txt

--- a/plugins/mewbot-discord_dice_roller/requirements.txt
+++ b/plugins/mewbot-discord_dice_roller/requirements.txt
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-mewbot.api
+mewbot-api
 d20

--- a/plugins/mewbot-io-discord/LICENSE.md
+++ b/plugins/mewbot-io-discord/LICENSE.md
@@ -1,0 +1,1 @@
+../../LICENSES/BSD-2-Clause.txt

--- a/plugins/mewbot-io-discord/README.md
+++ b/plugins/mewbot-io-discord/README.md
@@ -1,0 +1,23 @@
+<!--
+SPDX-FileCopyrightText: 2023 Mewbot Developers <mewbot@quicksilver.london>
+
+SPDX-License-Identifier: BSD-2-Clause
+-->
+
+# mewbot-io-discord
+
+This module serves two purposes
+
+1) adds discord functionality to mewbot
+
+2) serves as an example of how to configure a mewbot namespace plugin
+
+A mewbot namespace plugin is a plugin used to extend the framework itself.
+Mostly in the context of additional IOConfigs.
+After installing this module, you'll be able to import the discord IOConfig directly from mewbot.io as follows
+
+```python
+from mewbot.io.discord import DiscordIO
+```
+
+This is - typically - how new IOConfigs - interfaces to allow mewbot to talk to more protocols - should be written.

--- a/plugins/mewbot-io-discord/requirements.txt
+++ b/plugins/mewbot-io-discord/requirements.txt
@@ -4,3 +4,6 @@
 
 # Discord Module
 py-cord~=2.4.0
+
+# Mewbot
+mewbot-api

--- a/plugins/mewbot-io-discord/setup.py
+++ b/plugins/mewbot-io-discord/setup.py
@@ -4,29 +4,20 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-"""
-Installs the mewbot-discord_dice_roller example package on your system.
-
-Note - when building a development environment, use of this file can be a little annoying.
-In particular, it generates an egg-info folder in the same root as this file.
-Which confuses some linters (in particular, mypy).
-It's recommended that, if your preparing a mewbot dev environment, use the script
-src/mewbot/tools/dev_venv.py
-"""
-
 import os
 from pathlib import Path
 
 import setuptools  # type: ignore
 
-# Finding the right README.md
-plugin_dir = Path(__file__).parent
-root_repo_dir = plugin_dir.parent.parent
+# Finding the right README.md and inheriting the mewbot licence
+current_file = Path(__file__)
+root_repo_dir = current_file.parents[2]
 assert root_repo_dir.exists()
-with (plugin_dir / "README.md").open("r", encoding="utf-8") as rmf:
+
+with open(current_file.parent.joinpath("README.md"), "r", encoding="utf-8") as rmf:
     long_description = rmf.read()
 
-with (plugin_dir / "requirements.txt").open("r", encoding="utf-8") as rf:
+with open(current_file.parent.joinpath("requirements.txt"), "r", encoding="utf-8") as rf:
     requirements = list(x for x in rf.read().splitlines(False) if x and not x.startswith("#"))
 
 # Reading the LICENSE file and parsing the results
@@ -56,29 +47,25 @@ else:
         "to that resource."
     )
 
-
 # There are a number of bits of special sauce in this call
 # - You can fill it out manually - for your project
 # - You can copy this and make the appropriate changes
-# - Or you can run "mewbot make_new_plugin" - and follow the onscreen instructions.
+# - Or you can run "mewbot make_namespace_plugin" - and follow the onscreen instructions.
 #   Which should take care of most of the fiddly bits for you.
 setuptools.setup(
-    name="mewbot-discord_dice_roller",  # Note the different "-" and "_" between this
-    # and the entry_points/py_modules
-    # However, here, note it's "mewbot-" - not "mewbot_"
-    # If it's not "mewbot-" then the pattern the plugin manager uses to load plugins will fail
+    name="mewbot-io-discord",
     version="0.0.1",
     author="Alex Cameron",
     install_requires=requirements,
     author_email="mewbot@quicksilver.london",
-    description="Example discord dice roller for mewbot",
+    description="Mewbot Developers (https://github.com/mewbotorg)",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/mewbotorg/mewbot",
+    url="https://github.com/mewler/mewbot",
     project_urls={
-        "Bug Tracker": "https://github.com/mewbotorg/mewbot/issues",
+        "Bug Tracker": "https://github.com/mewler/mewbot/issues",
     },
-    license=license_text,
+    license=true_license_text,
     classifiers=[
         "Programming Language :: Python :: 3",
         f"License :: OSI Approved :: {true_license_ident}",
@@ -86,15 +73,13 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     package_dir={"": "src"},
-    packages=setuptools.find_packages(where="src"),
+    packages=setuptools.find_namespace_packages(where="src", include=["mewbot.*"]),
     # see https://packaging.python.org/en/latest/specifications/entry-points/
     # Note -
-    entry_points={"mewbot_v1": ["discord_dice_roller = mewbot_discord_dice_roller"]},
+    entry_points={"mewbot_v1": ["discord_io = mewbot.io.discord"]},
     # Note this setup
     # The key for the entry point should always be "mewbot"
     # The value should be a string of the form "{prefix less name} = {py_modules name}"
     # The "py_modules name" should match one of the py_modules declared below
     python_requires=">=3.9",  # Might be relaxed later
-    py_modules=["mewbot_discord_dice_roller"],
 )
-

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def main() -> None:
     version = "0.0.1"
     config: Dict[str, Union[str, List[str]]] = {
         "version": version,
-        "author": "Mewbot Developers (https://github.com/mewler)",
+        "author": "Mewbot Developers (https://github.com/mewbotorg)",
         "author_email": "mewbot@quicksilver.london",
         "description": "Lightweight, YAML-driven, text based, generic irc Bot framework",
         "license_files": ["LICENSE.md"],


### PR DESCRIPTION
 - added functional setup.py files for all the plugins
 - determine installation order to achieve a functioning venv using the setup.py scripts for mewbot and all the plugins
 - constructed a helper script to build and test such a venv
 - (helper script is deliberately stand alone - with no dependencies outside the standard library or from elsewhere in mewbot)
 - more work can be done - but the helper script and plugin setup.py files are feature complete

Submitting this to check direction before this continues to grow as a project.