### PR TITLE
Drop support for python 3.9

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # Which version of the reports Sonar receives.
   DEFAULT_OS: ubuntu
-  DEFAULT_PYTHON: 3.9
+  DEFAULT_PYTHON: "3.10"
 
 jobs:
   test:
@@ -30,7 +30,7 @@ jobs:
       matrix:
         name: ["lint", "test"]
         os: ["ubuntu", "macos", "windows"]
-        version: ["3.9", "3.10", "3.11"]
+        version: ["3.10", "3.11"]
         exclude:
           - name: Lint
             os: macos

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ enforce the code style and linting requirements of this project.
 
 #### Setting up project for local development
 
-The recommended way to set this project up is using python 3.9 (or higher) with
+The recommended way to set this project up is using python 3.10 (or higher) with
 a standard `venv` setup.
 The project uses a "src-dir" layout; for Python to be able to locate the modules, 
 you will need to set up the `PYTHONPATH` environment variable with at least the `src/` directory.

--- a/dev-docs/windows_dev_install/1 - Introduction and checklist.md
+++ b/dev-docs/windows_dev_install/1 - Introduction and checklist.md
@@ -34,13 +34,13 @@ This is just what I do - your setup is allowed to look very different.
 
 1) Install all the software I need
    1) `git` - which I use mostly through `github desktop` on windows
-   2) `python` - versions `3.9`, `3.10` and `3.11`
+   2) `python` - versions `3.10` and `3.11`
 2) Make a folder in the root of - `C:\mewbot_dev`
 3) Clone the repo into it - so the files will be at `C:\mewbot_dev\mewbot`
 4) Set up a command precall `.bat` file - which I use for alias'd commands and shortcuts.
         This process is intimidating, but the added utility is significant.
 5) Set up a `venv` for each version of python
-6) Add alias to the command precall file so I can activate each `venv` easily (e.g. the command `activate_mewbot_venv_39` will activate the `venv` for `python3.9`)
+6) Add alias to the command precall file so I can activate each `venv` easily (e.g. the command `activate_mewbot_venv_310` will activate the `venv` for `python3.10`)
 7) I will usually add other utility shortcuts to make dev easier at this time - e.g. aliasing `dir` to `ls`
 8) For each `venv` I
    1) activate it

--- a/dev-docs/windows_dev_install/2 - Install required programs.md
+++ b/dev-docs/windows_dev_install/2 - Install required programs.md
@@ -20,30 +20,17 @@ Installation media should be obtained directly from [the python downloads page][
 
 #### But which version of python?
 
-Mewbot currently targets python 3.9, 3.10 and 3.11 - as of March 2023.
+Mewbot currently targets python 3.10, 3.11 - as of June 2023.
 We will continue to target new versions as they release.
-We are currently working with python 3.9 - and these steps have been tested as working with 3.10 and 3.11
 
-It is, often, useful to have all the versions of python which mewbot targets on your local machine.
+You can develop using any supported version of python.
+These steps have been tested as working with 3.10 and 3.11.
 
-However, you should _mostly_ use python 3.9.
-
-The reason is that Mewbot uses several tools called linters to ensure code consistency and quality.
-Linters statically analyse the code to determine if it meets certain requirements.
-They should be run - and pass - before you issue a pull request to ask us to include your code in mewbot.
-When such a request is issued on github, they are run automatically to check the code over.
-Code which does not pass linting _cannot_ be merged.
-
-Github runs the linters through the lowest version of python which a project targets - in this case `python3.9`.
-As such, the linters will be run remotely against the code using `python3.9`.
-Different versions of python have - slightly - different linting behavior.
-Thus code which passes linting on `python3.9` _may_ or _may not_ pass linting by the same tool on `python3.10`.
-(Is this annoying? Immensely!)
-
-We _do not_ run linting on every version of python we target.
-But we do run testing against every version of python we target.
-So it's often useful to have all the versions of python we target on hand for testing purposes.
-Thus, you might want to install pythons `3.9`, `3.10` and `3.11`.
+The CI jobs (both linting and tests) are run against all targeted versions of Python.
+Code which does not pass linting and tests _cannot_ be merged.
+It can, therefore, be useful to have all the versions of targeted versions of Python
+available on your local machine, so you can investigate any issues that the CI jobs
+are reporting.
 
 #### Which linters do you use and how do I install them?
 
@@ -73,7 +60,7 @@ During python installation
 * Selecting "Add Python to environment variables" is a useful addition - but one you might want to avoid if you already have another version of python already installed. As this may cause confusion. 
       In this case you probably want to install without this ticked and use the full path to your python executable in all that follows (once you have the venv setup, this should cease to be necessary).
 * The default install location is somewhat buried in the file structure. 
-      I personally prefer to change it to something like "C:\Python39\" - but this is a taste thing. It shouldn't affect subsequent steps. However, it's arguably better to keep the path to the python executable short. As it cuts down on typing and potential error.
+      I personally prefer to change it to something like "C:\Python310\" - but this is a taste thing. It shouldn't affect subsequent steps. However, it's arguably better to keep the path to the python executable short. As it cuts down on typing and potential error.
 
 ### 2) Install git
 

--- a/dev-docs/windows_dev_install/3 - Add python to the path.md
+++ b/dev-docs/windows_dev_install/3 - Add python to the path.md
@@ -26,7 +26,7 @@ Python 3.10.0 (tags/v3.10.0:b494f59, Oct  4 2021, 19:00:18) [MSC v.1929 64 bit (
 Type "help", "copyright", "credits" or "license" for more information.
 >>>
 ```
-(my default python is `3.10` - yours could be `3.9` or otherwise).
+(my default python is `3.10` - yours could be `3.11` or otherwise).
 
 You could work directly with the full path to the python executable in subsequent steps, but this might be a little verbose.
 

--- a/dev-docs/windows_dev_install/5 - Create venvs.md
+++ b/dev-docs/windows_dev_install/5 - Create venvs.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: BSD-2-Clause
 ## prepare venvs
 
 (Perhaps for all the versions of mewbot we're targeting.
-Perhaps just for `3.9` - it's sorta up to you.)
+Perhaps just for `3.10` - it's sorta up to you.)
 
 A `venv` is a `virtual environment` - a copy of your python interpreter which can operate independently of the installed python.
 It's all contained in a single folder - which can be removed and recreated if anything goes awry.
@@ -93,8 +93,7 @@ My command precall file, at this stage of the install process, ended up looking 
 
 ```shell
 @echo off
-doskey activate_mewbot_venv=C:\mewbot_dev\mewbot_venv_39\Scripts\activate
-doskey activate_mewbot_venv_39=C:\mewbot_dev\mewbot_venv_39\Scripts\activate
+doskey activate_mewbot_venv=C:\mewbot_dev\mewbot_venv_310\Scripts\activate
 doskey activate_mewbot_venv_310=C:\mewbot_dev\mewbot_venv_310\Scripts\activate
 doskey activate_mewbot_venv_311=C:\mewbot_dev\mewbot_venv_311\Scripts\activate
 DOSKEY python3 = C:\\Python310\\python.exe $*
@@ -102,7 +101,7 @@ DOSKEY ls=dir /B $*
 :END
 ```
 
-With `venvs` for pythons `3.9`, `3.10` and `3.11`.
+With `venvs` for pythons `3.10` and `3.11`.
 
 This allows me to now, from where ever I am on the system, activate the venv with "activate_mewbot_venv" ... deactivation is left as an exercise to the reader.
 

--- a/dev-docs/windows_dev_install/8 - Run linters and tests.md
+++ b/dev-docs/windows_dev_install/8 - Run linters and tests.md
@@ -147,7 +147,7 @@ Note that the path to get to the script uses  `tools/lint` _not_ `tools\lint` - 
 
 If you've gotten it the wrong way round, you should get an error something like this
 ```shell
-(mewbot_venv_39) C:\mewbot_dev\mewbot>sh tools\lint
+(mewbot_venv_310) C:\mewbot_dev\mewbot>sh tools\lint
 tools\lint: line 7: tools\lint/path: Not a directory
 tools\lint: line 9: exec: : not found
 ```

--- a/dev-docs/windows_dev_install/quickstart.md
+++ b/dev-docs/windows_dev_install/quickstart.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: BSD-2-Clause
 # Quickstart for experience developers on Windows
 
 1) Clone the `src` somewhere sensible
-2) Install the earliest version of python `mewbot` supports. The linters, tests e.t.c on the remote host run on the earliest version of python supported by mewbot - at present `3.9`. So we suggest using this for dev.
+2) Install the earliest version of python `mewbot` supports - at present `3.10`. We suggest using the oldest version to avoid developing with features that do not exist in `3.10`.
 3) As ever, we recommend using a `venv`, but it's up to you. If you do, activate it now.
 4) `cd` into the cloned `mewbot` repo
 5) Install requirements for the main program with `pip install -r requirements-dev.txt` (or `python -m pip install -r requirements-dev.txt` if you don't have `pip` on the path)

--- a/dev-docs/windows_dev_install/troubleshooting.md
+++ b/dev-docs/windows_dev_install/troubleshooting.md
@@ -8,9 +8,12 @@ SPDX-License-Identifier: BSD-2-Clause
 
 ### Are you running the right version of python?
 
-Github - when running a testing or linting script - uses the lowest version of python the package supports.
-In our case, this is `python3.9`.
-If you are not running `python3.9` then repeat the setup steps with it as your main python interpreter/venv and see if the error persists.
+GitHub - when running a testing or linting script - shows the version of python it is running under.
+When looks at these issues, check what version of python you are using (`python --version`).
+If the error shows for a different version of python, try again using a matching version of python. 
+
+Note: we generally recommend developing mewbot with the lowest version of python we target (currently `3.10`).
+This prevents accidentally developing using features that do not exist in all targeted versions. 
 
 ## I'm making changes to the mewbot files, and they're not showing up
 

--- a/plugins/mewbot-discord_dice_roller/setup.py
+++ b/plugins/mewbot-discord_dice_roller/setup.py
@@ -69,7 +69,7 @@ raise NotImplementedError("Still under development.")
 #     # The key for the entry point should always be "mewbot"
 #     # The value should be a string of the form "{prefix less name} = {py_modules name}"
 #     # The "py_modules name" should match one of the py_modules declared below
-#     python_requires=">=3.9",  # Might be relaxed later
+#     python_requires=">=3.10",  # Might be relaxed later
 #     py_modules=["mewbot_discord_dice_roller"],
 # )
 #

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ def main() -> None:
         "description": "Lightweight, YAML-driven, text based, generic irc Bot framework",
         "license_files": ["LICENSE.md"],
         "url": "https://github.com/mewler/mewbot",
-        "python_requires": ">=3.9",
+        "python_requires": ">=3.10",
         "classifiers": [
             "Programming Language :: Python :: 3",
             "Operating System :: OS Independent",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,7 +17,7 @@ sonar.cpd.exclusions = src/examples/**/*
 
 sonar.links.scm=https://github.com/mewler/mewbot
 
-sonar.python.version=3.9, 3.10, 3.11
+sonar.python.version=3.10, 3.11, 3.12
 sonar.python.coverage.reportPaths=reports/coverage.xml
 sonar.python.xunit.reportPath=reports/junit.xml
 sonar.python.flake8.reportPaths=reports/Flake8.txt


### PR DESCRIPTION
- Gains access to [PEP634](https://peps.python.org/pep-0634/) and the `match` statement
- Gains access to [PEP647](https://peps.python.org/pep-0647/) `TypeGuard` types
- Gains access to [PEP604](https://peps.python.org/pep-0604/) Generic union types `X | Y`

More information at https://docs.python.org/3/whatsnew/3.10.html

The primary motivation for this change is it will significantly simplify #203 