### PR TITLE
Hardened linting against non utf-8 characters in the output

### DIFF
--- a/src/mewbot/tools/lint.py
+++ b/src/mewbot/tools/lint.py
@@ -167,7 +167,12 @@ class LintToolchain(BanditMixin):
 
         result = self.run_tool("PyLint", "pylint")
 
-        for line in result.stdout.decode("utf-8").split("\n"):
+        try:
+            result_lines = result.stdout.decode("utf-8")
+        except UnicodeError:
+            result_lines = result.stdout.decode("utf-8", errors="replace")
+
+        for line in result_lines.split("\n"):
             if ":" not in line:
                 continue
 

--- a/src/mewbot/tools/lint.py
+++ b/src/mewbot/tools/lint.py
@@ -167,10 +167,7 @@ class LintToolchain(BanditMixin):
 
         result = self.run_tool("PyLint", "pylint")
 
-        try:
-            result_lines = result.stdout.decode("utf-8")
-        except UnicodeError:
-            result_lines = result.stdout.decode("utf-8", errors="replace")
+        result_lines = result.stdout.decode("utf-8", errors="replace")
 
         for line in result_lines.split("\n"):
             if ":" not in line:


### PR DESCRIPTION
 - provides a fallback if a non-utf character is encountered while processing linting output.