### PR TITLE
core: Bumping version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def main() -> None:
     Wrap setuptools with dynamically generated packages and information.
     """
 
-    version = "0.0.1"
+    version = "0.0.2"
     config: Dict[str, Union[str, List[str]]] = {
         "version": version,
         "author": "Mewbot Developers (https://github.com/mewbotorg)",


### PR DESCRIPTION
 - I need the src/mewbot/test folder to get some tests working in the mewbot-io-discord plugin
 - turns out, pypi doesn't allow version overwrite - so creating a new release without incrementing the version does not change the available files
 - hence the version bump