### PR TITLE
api: Add a display property to all components - Option 2

### DIFF
--- a/src/mewbot/api/display.py
+++ b/src/mewbot/api/display.py
@@ -1,0 +1,64 @@
+"""
+Stores classes which produce a display from mewbot objects.
+
+This display - for the moment - is mostly just text.
+"""
+
+
+from typing import Any
+
+import inspect
+
+
+class TextDisplay:
+    """
+    Provides a collection of utility functions with sensible human-readable defaults.
+
+    These include
+    - name
+    - help
+    - status
+    - description
+    """
+
+    _internal_obj: Any
+
+    def __init__(self, internal_object: Any) -> None:
+        """
+        Attach the TextDisplay class to an actual object.
+        """
+        self._internal_obj = internal_object
+
+    def help(self) -> str:
+        """
+        Returns a human-readable help string for this InputEvent.
+
+        Practically, should be rarely used - included for completeness.
+        """
+        return inspect.getsource(type(self._internal_obj))
+
+    def name(self) -> str:
+        """
+        Return a human-readable display name for this InputEvent.
+
+        Used for formatting logging statements.
+        """
+        return type(self._internal_obj).__name__
+
+    def description(self) -> str:
+        """
+        Return a human-readable description of this InputEvent.
+
+        Eventually, may include details such as
+         - which IOConfig generated it
+         - when
+        """
+        if (cand_str := type(self._internal_obj).__doc__) is not None:
+            return cand_str
+        return f"{self.name()} has no doc string set."
+
+    def status(self) -> str:
+        """
+        Return a human-readable status for this InputEvent.
+        """
+        return f"InputEvent - {self.name()} has not had a particular status set."

--- a/src/mewbot/api/v1.py
+++ b/src/mewbot/api/v1.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, TypeVar, Union, get_args, get_origin, get_type
 import abc
 import functools
 
+from mewbot.api.display import TextDisplay
 from mewbot.api.registry import ComponentRegistry
 from mewbot.core import (
     ActionInterface,
@@ -51,6 +52,14 @@ class Component(metaclass=ComponentRegistry):
     """
 
     _id: str
+    _display: TextDisplay
+
+    @property
+    def display(self) -> TextDisplay:
+        """
+        Return the current Display for this component.
+        """
+        return self._display
 
     def serialise(self) -> ConfigBlock:
         """
@@ -154,9 +163,18 @@ class Input:
     """
 
     queue: InputQueue | None
+    _display: TextDisplay
 
     def __init__(self) -> None:
         self.queue = None
+        self._display = TextDisplay(self)
+
+    @property
+    def display(self) -> TextDisplay:
+        """
+        Provides a text based display for this input.
+        """
+        return self._display
 
     @staticmethod
     @abc.abstractmethod
@@ -190,6 +208,21 @@ class Output:
     the output queue, and passes it to all Outputs that declare that
     they can consume it.
     """
+
+    _display: TextDisplay
+
+    def __init__(self) -> None:
+        """
+        Mostly needed to declare the display.
+        """
+        self._display = TextDisplay(self)
+
+    @property
+    def display(self) -> TextDisplay:
+        """
+        Get the display responsible for generating information for this Output.
+        """
+        return self._display
 
     @staticmethod
     @abc.abstractmethod

--- a/src/mewbot/core/__init__.py
+++ b/src/mewbot/core/__init__.py
@@ -28,6 +28,8 @@ import asyncio
 import dataclasses
 import enum
 
+from mewbot.api.display import TextDisplay
+
 
 @dataclasses.dataclass
 class InputEvent:
@@ -40,6 +42,14 @@ class InputEvent:
     This base event has no data or properties. Events must be immutable.
     """
 
+    display: TextDisplay = dataclasses.field(init=False)
+
+    def __post_init__(self) -> None:
+        """
+        Allows a TextDisplay to be initialised without changing the default init behavior.
+        """
+        self.display = TextDisplay(self)
+
 
 @dataclasses.dataclass
 class OutputEvent:
@@ -51,6 +61,14 @@ class OutputEvent:
 
     This base event has no data or properties. Events must be immutable.
     """
+
+    display: TextDisplay = dataclasses.field(init=False)
+
+    def __post_init__(self) -> None:
+        """
+        Allows a TextDisplay to be initialised without changing the default init behavior.
+        """
+        self.display = TextDisplay(self)
 
 
 InputQueue = asyncio.Queue[InputEvent]
@@ -79,6 +97,12 @@ class IOConfigInterface(Protocol):
     once, or generated on request as part of the bot's lifecycle. Either way,
     they are passed to the bot via the `get_inputs` and `get_outputs` methods.
     """
+
+    @property
+    def display(self) -> TextDisplay:
+        """
+        Display logic reporting on the status of this IOConfig.
+        """
 
     def get_inputs(self) -> Iterable[InputInterface]:
         """
@@ -109,6 +133,12 @@ class InputInterface(Protocol):
     Inputs connect to a system, ingest events in some way, and put them
     into the bot's input event queue for processing.
     """
+
+    @property
+    def display(self) -> TextDisplay:
+        """
+        Display logic reporting on the status of this IOConfig.
+        """
 
     @staticmethod
     def produces_inputs() -> set[type[InputEvent]]:
@@ -141,6 +171,12 @@ class OutputInterface(Protocol):
     they can consume it.
     """
 
+    @property
+    def display(self) -> TextDisplay:
+        """
+        Display logic reporting on the status of this IOConfig.
+        """
+
     @staticmethod
     def consumes_outputs() -> set[type[OutputEvent]]:
         """Defines the types of Event that this Output class can send."""
@@ -164,6 +200,12 @@ class TriggerInterface(Protocol):
     Triggers should refrain from adding too many sub-clauses and conditions.
     Filtering behaviours is the role of the Condition Component.
     """
+
+    @property
+    def display(self) -> TextDisplay:
+        """
+        Display logic reporting on the status of this IOConfig.
+        """
 
     @staticmethod
     def consumes_inputs() -> set[type[InputEvent]]:
@@ -193,6 +235,12 @@ class ConditionInterface(Protocol):
     see all events.
     """
 
+    @property
+    def display(self) -> TextDisplay:
+        """
+        Display logic reporting on the status of this IOConfig.
+        """
+
     @staticmethod
     def consumes_inputs() -> set[type[InputEvent]]:
         """
@@ -216,6 +264,12 @@ class ActionInterface(Protocol):
      - Emit OutputEvents to the queue
      - Add data to the state, which will be available to the other actions in the behaviour
     """
+
+    @property
+    def display(self) -> TextDisplay:
+        """
+        Display logic reporting on the status of this IOConfig.
+        """
 
     @staticmethod
     def consumes_inputs() -> set[type[InputEvent]]:
@@ -261,6 +315,12 @@ class BehaviourInterface(Protocol):
     accept the Event. Assuming it does, the Actions for the Behaviour are executed in
     order, which can read from or write to DataStores, and emit OutputEvents.
     """
+
+    @property
+    def display(self) -> TextDisplay:
+        """
+        Display logic reporting on the status of this IOConfig.
+        """
 
     def add(self, component: TriggerInterface | ConditionInterface | ActionInterface) -> None:
         """

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -16,6 +16,7 @@ import abc
 
 import pytest
 
+from mewbot.api.display import TextDisplay
 from mewbot.api.registry import ComponentRegistry
 from mewbot.api.v1 import Condition, InputEvent
 from mewbot.core import ComponentKind
@@ -66,6 +67,13 @@ class TestRegistry:
             """
             Private class for testing.
             """
+
+            @property
+            @abc.abstractmethod
+            def display(self) -> TextDisplay:
+                """
+                May provide a display for this object - might not.
+                """
 
             @staticmethod
             @abc.abstractmethod


### PR DESCRIPTION
Aim is to localise all the "display" ("render this object human readable") code in one place.
This is by contrast to Option 1 - New human readable options at the top level of every object

Pros
 - more elegant - fewer methods to have to worry about in each object
 - helps with mental namespacing (I think that calling "Object.display.name" gets me a human readable name is more obvious than just calling "Object.name" - but the distinction discussed on signal - using magic methods for devs and methods for users - also makes good sense)
 - keeps objects from being cluttered with methods
 - makes business logic more clearly distinct from display logic

Cons
 - marginalises a core part of the functionality of each object - may encourage people to just focus on the business logic aspect of a new class - not the human intractability (on the other hand, this may be a benefit - one dev can work on business logic, the other on human intractability)
 - arguably less clear
 - requires a separate system of contracts for what properties display objects have